### PR TITLE
Prevent target block attributes from being reused in other blocks

### DIFF
--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -127,7 +127,7 @@ func ResolveAttributeValue(ctx context.Context, definitionLinkSupport bool, mana
 			if isInsideRange(e.Range(), position) {
 				if templateExpr, ok := e.(*hclsyntax.TemplateExpr); ok {
 					if templateExpr.IsStringLiteral() {
-						if attribute.Name == "inherits" {
+						if attribute.Name == "inherits" && sourceBlock.Type == "target" {
 							value, _ := templateExpr.Value(&hcl.EvalContext{})
 							target := value.AsString()
 							return CalculateBlockLocation(input, body, documentURI, "target", target, false)
@@ -210,7 +210,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 	if objectConsExpression, ok := expression.(*hclsyntax.ObjectConsExpr); ok {
 		for _, item := range objectConsExpression.Items {
 			if isInsideRange(item.KeyExpr.Range(), position) {
-				if attributeName == "args" {
+				if attributeName == "args" && sourceBlock.Type == "target" {
 					start := item.KeyExpr.Range().Start.Byte
 					end := item.KeyExpr.Range().End.Byte
 					if LiteralValue(item.KeyExpr) {

--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -526,6 +526,34 @@ func TestDefinition(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "group block with an invalid inherits attribute should not return a result",
+			content:   "target t1 {}\ngroup g1 { inherits = [\"t1\"] }",
+			line:      1,
+			character: 25,
+			links:     nil,
+		},
+		{
+			name:      "variable block with an invalid inherits attribute should not return a result",
+			content:   "target t1 {}\nvariable v1 { inherits = [\"t1\"] }",
+			line:      1,
+			character: 28,
+			links:     nil,
+		},
+		{
+			name:      "args key should not reference in a group block",
+			content:   "group g1 {\n  args = {\n    var = \"value\"\n  }\n}",
+			line:      2,
+			character: 6,
+			links:     nil,
+		},
+		{
+			name:      "args key should not reference in a variable block",
+			content:   "variable var {\n  args = {\n    var = \"value\"\n  }\n}",
+			line:      2,
+			character: 6,
+			links:     nil,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -684,6 +712,38 @@ func TestDefinitionVariedResults(t *testing.T) {
 					},
 				},
 			},
+		},
+		{
+			name:      "no-cache-filter attribute should not work in a group block",
+			content:   "group \"g1\" { no-cache-filter = [\"stage\"] }",
+			line:      0,
+			character: 39,
+			locations: nil,
+			links:     nil,
+		},
+		{
+			name:      "no-cache-filter attribute should not work in a variable block",
+			content:   "variable \"var\" {\ndockerfile = \"Dockerfile\"\ntarget = \"stage\" }",
+			line:      2,
+			character: 13,
+			locations: nil,
+			links:     nil,
+		},
+		{
+			name:      "target attribute should not work in a group block",
+			content:   "group \"g1\" { target = \"stage\" }",
+			line:      0,
+			character: 25,
+			locations: nil,
+			links:     nil,
+		},
+		{
+			name:      "target attribute should not work in a variable block",
+			content:   "variable \"var\" { target = \"stage\" }",
+			line:      0,
+			character: 30,
+			locations: nil,
+			links:     nil,
 		},
 	}
 


### PR DESCRIPTION
We have a lot of support for `textDocument/definition` requests for attributes within a target block. Some of them assumed that these attributes would only ever be found on a target block so if they were replicated inside a different block (such as group or variable) then the `textDocument/definition` request would still get results back.

Additional checks have now been introduced to ensure that we only respond to those requests if they were sent for a position inside a target block.