### PR TITLE
Allow jumping to a target from a group block

### DIFF
--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -127,7 +127,11 @@ func ResolveAttributeValue(ctx context.Context, definitionLinkSupport bool, mana
 			if isInsideRange(e.Range(), position) {
 				if templateExpr, ok := e.(*hclsyntax.TemplateExpr); ok {
 					if templateExpr.IsStringLiteral() {
-						if attribute.Name == "inherits" && sourceBlock.Type == "target" {
+						// look up a target reference if it's inside a
+						// target block's inherits attribute, or a
+						// group block's targets attribute
+						if (sourceBlock.Type == "target" && attribute.Name == "inherits") ||
+							(sourceBlock.Type == "group" && attribute.Name == "targets") {
 							value, _ := templateExpr.Value(&hcl.EvalContext{})
 							target := value.AsString()
 							return CalculateBlockLocation(input, body, documentURI, "target", target, false)

--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -184,6 +184,21 @@ func TestDefinition(t *testing.T) {
 			},
 		},
 		{
+			name:      "group block's targets attribute points to a valid target",
+			content:   "target \"t1\" {}\ngroup \"g1\" {\n  targets = [ \"t1\" ]\n}",
+			line:      2,
+			character: 16,
+			links: []protocol.Location{
+				{
+					URI: bakeFileURI,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 8},
+						End:   protocol.Position{Line: 0, Character: 10},
+					},
+				},
+			},
+		},
+		{
 			name:      "inherits attribute points to an unquoted variable",
 			content:   "variable \"var\" {}\ntarget \"default\" {\n  inherits = [ var ]\n}",
 			line:      2,


### PR DESCRIPTION
Support `textDocument/definition` requests for jumping from a `group` block's `targets` attribute to the referenced `target` block.