### PR TITLE
Remove the unused "file" argument from the CodeLens command

### DIFF
--- a/internal/bake/hcl/codeLens.go
+++ b/internal/bake/hcl/codeLens.go
@@ -58,7 +58,6 @@ func createCodeLens(title, filename, call, target string, rng protocol.Range) pr
 			Command: types.BakeBuildCommandId,
 			Arguments: []any{
 				map[string]string{
-					"file":   filename,
 					"call":   call,
 					"target": target,
 					"cwd":    filepath.Dir(types.StripLeadingSlash(filename)),

--- a/internal/bake/hcl/codeLens_test.go
+++ b/internal/bake/hcl/codeLens_test.go
@@ -36,7 +36,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "build",
 								"target": "first",
 								"cwd":    "/tmp",
@@ -54,7 +53,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "check",
 								"target": "first",
 								"cwd":    "/tmp",
@@ -72,7 +70,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "print",
 								"target": "first",
 								"cwd":    "/tmp",
@@ -96,7 +93,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "build",
 								"target": "g1",
 								"cwd":    "/tmp",
@@ -114,7 +110,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "check",
 								"target": "g1",
 								"cwd":    "/tmp",
@@ -132,7 +127,6 @@ func TestCodeLens(t *testing.T) {
 						Command: types.BakeBuildCommandId,
 						Arguments: []any{
 							map[string]string{
-								"file":   "/tmp/docker-bake.hcl",
 								"call":   "print",
 								"target": "g1",
 								"cwd":    "/tmp",


### PR DESCRIPTION
Since the command will just run Bake without specifying a file, the `"file"` argument can be removed as it will not actually be used by the client.