### PR TITLE
Use filepath.Dir to get the parent folder

### DIFF
--- a/internal/bake/hcl/completion_test.go
+++ b/internal/bake/hcl/completion_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
@@ -18,7 +19,7 @@ import (
 func TestCompletion(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	projectRoot := path.Join(wd, "..", "..", "..")
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(wd)))
 	completionTestFolderPath := path.Join(projectRoot, "testdata", "completion")
 
 	testCases := []struct {

--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -44,7 +45,7 @@ func TestLocalDockerfileForWindows(t *testing.T) {
 func TestDefinition(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	projectRoot := path.Join(wd, "..", "..", "..")
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(wd)))
 	definitionTestFolderPath := path.Join(projectRoot, "testdata", "definition")
 	dockerfilePath := path.Join(definitionTestFolderPath, "Dockerfile")
 	dockerfileURI := fmt.Sprintf("file://%v", dockerfilePath)
@@ -585,7 +586,7 @@ func TestDefinition(t *testing.T) {
 func TestDefinitionVariedResults(t *testing.T) {
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	projectRoot := path.Join(wd, "..", "..", "..")
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(wd)))
 	definitionTestFolderPath := path.Join(projectRoot, "testdata", "definition")
 	dockerfilePath := path.Join(definitionTestFolderPath, "Dockerfile")
 	dockerfileURI := fmt.Sprintf("file://%v", dockerfilePath)

--- a/internal/bake/hcl/diagnosticsCollector_test.go
+++ b/internal/bake/hcl/diagnosticsCollector_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
@@ -197,7 +198,7 @@ target "lint2" {
 
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	projectRoot := path.Join(wd, "..", "..", "..")
+	projectRoot := filepath.Dir(filepath.Dir(filepath.Dir(wd)))
 	diagnosticsTestFolderPath := path.Join(projectRoot, "testdata", "diagnostics")
 	bakeFilePath := path.Join(diagnosticsTestFolderPath, "docker-bake.hcl")
 	bakeFileURI := uri.URI(fmt.Sprintf("file://%v", bakeFilePath))


### PR DESCRIPTION
The `path` package does not deal with Windows paths with drive letters so it would best to change our tests to use `filepath.Dir` instead of using the `path` package.