### PR TITLE
Fix completion_test.go tests on Windows

### DIFF
--- a/internal/bake/hcl/completion_test.go
+++ b/internal/bake/hcl/completion_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
@@ -340,9 +341,15 @@ func TestCompletion(t *testing.T) {
 		},
 	}
 
-	bakeFilePath := path.Join(completionTestFolderPath, "docker-bake.hcl")
-	bakeFileURI := uri.URI(fmt.Sprintf("file://%v", bakeFilePath))
-	dockerfileURI := uri.URI(fmt.Sprintf("file://%v", path.Join(completionTestFolderPath, "Dockerfile")))
+	bakeFilePath := filepath.Join(completionTestFolderPath, "docker-bake.hcl")
+	bakeFilePath = filepath.ToSlash(bakeFilePath)
+
+	dockerfilePath := filepath.Join(completionTestFolderPath, "Dockerfile")
+	dockerfilePath = filepath.ToSlash(dockerfilePath)
+
+	bakeFileURI := uri.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(bakeFilePath, "/")))
+	dockerfileURI := uri.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(dockerfilePath, "/")))
+
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			manager := document.NewDocumentManager()

--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -377,7 +377,7 @@ func ParseDockerfile(dockerfilePath string) ([]byte, *parser.Result, error) {
 }
 
 func OpenDockerfile(ctx context.Context, manager *document.Manager, path string) ([]byte, []*parser.Node) {
-	doc := manager.Get(ctx, uri.URI(fmt.Sprintf("file://%v", path)))
+	doc := manager.Get(ctx, uri.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(path), "/"))))
 	if doc != nil {
 		if dockerfile, ok := doc.(document.DockerfileDocument); ok {
 			return dockerfile.Input(), dockerfile.Nodes()


### PR DESCRIPTION
Due to Windows paths having drive letters and having backslashes, `completion_test.go` was not passing. Replacing `path.Join` with `filepath.Join` and ensuring URIs are created properly on all platforms fixes the problem.