### PR TITLE
Renames a test that was using a duplicated name

### DIFF
--- a/internal/bake/hcl/completion_test.go
+++ b/internal/bake/hcl/completion_test.go
@@ -199,7 +199,7 @@ func TestCompletion(t *testing.T) {
 			},
 		},
 		{
-			name:              "target attribute in target block returns nothing for empty dockerfile-inline",
+			name:              "target attribute in target block returns content from manager (instead of what is on disk)",
 			content:           "target \"api\" {\n  target = \"\"\n}",
 			line:              1,
 			dockerfileContent: "FROM scratch AS override",


### PR DESCRIPTION
The name of a test was identical to another one due to a copy paste error. It has been renamed to more clearly identify what scenario the test is meant to be testing.