### PR TITLE
Generalize the paths used in e2e tests

### DIFF
--- a/e2e-tests/initialize_test.go
+++ b/e2e-tests/initialize_test.go
@@ -2,9 +2,11 @@ package server_test
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,7 +25,7 @@ func init() {
 func createDidOpenTextDocumentParams(homedir, testName, text string, languageID protocol.LanguageIdentifier) protocol.DidOpenTextDocumentParams {
 	return protocol.DidOpenTextDocumentParams{
 		TextDocument: protocol.TextDocumentItem{
-			URI:        protocol.URI(path.Join("file://", homedir, testName)),
+			URI:        protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(homedir, testName)), "/"))),
 			Text:       text,
 			LanguageID: languageID,
 			Version:    1,
@@ -35,7 +37,7 @@ func createDidChangeTextDocumentParams(homedir, testName, text string) protocol.
 	return protocol.DidChangeTextDocumentParams{
 		TextDocument: protocol.VersionedTextDocumentIdentifier{
 			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
-				URI: protocol.URI(path.Join("file://", homedir, testName)),
+				URI: protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(homedir, testName)), "/"))),
 			},
 			Version: 1,
 		},

--- a/e2e-tests/inlayHint_test.go
+++ b/e2e-tests/inlayHint_test.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -53,8 +54,8 @@ func TestInlayHint(t *testing.T) {
 		},
 	}
 
-	temporaryDockerfile := fmt.Sprintf("file://%v", path.Join(os.TempDir(), "Dockerfile"))
-	temporaryBakeFile := fmt.Sprintf("file://%v", path.Join(os.TempDir(), "docker-bake.hcl"))
+	temporaryDockerfile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "Dockerfile")), "/"))
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/e2e-tests/inlineCompletion_test.go
+++ b/e2e-tests/inlineCompletion_test.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -49,8 +50,8 @@ func TestInlineCompletion(t *testing.T) {
 		},
 	}
 
-	temporaryDockerfile := fmt.Sprintf("file://%v", path.Join(os.TempDir(), "Dockerfile"))
-	temporaryBakeFile := fmt.Sprintf("file://%v", path.Join(os.TempDir(), "docker-bake.hcl"))
+	temporaryDockerfile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "Dockerfile")), "/"))
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Replace `path.Join` with `filepath.Join` to make the core of the tests independent of the platform they are being run on.