### PR TITLE
Create a TELEMETRY.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,23 +63,6 @@ Use "docker-language-server [command] --help" for more information about a comma
 
 ## Configuration
 
-### Telemetry
-
-The Docker Language Server has telemetry which is **disabled** by default. Telemetry is only set on startup with the first incoming `initialized` request from the client. Please read our [privacy policy](https://www.docker.com/legal/docker-privacy-policy/) to learn more about how your data will be collected and used.
-
-```JSONC
-{
-  "clientInfo": {
-      "name": "clientName",
-      "version": "1.2.3"
-  },
-  "initializationOptions": {
-    // you can send enable all telemetry, only send errors, or disable it completely
-    "telemetry": "all" | "error" | "off"
-  }
-}
-```
-
 ### Experimental Capabilities
 
 To support `textDocument/codeLens`, the client must provide a command with the id `dockerLspClient.bake.build` for executing the build. If this is supported, the client can define its experimental capabilities as follows. The server will then respond that it supports code lens requests and return results for `textDocument/codeLens` requests for Bake HCL files.
@@ -97,6 +80,10 @@ To support `textDocument/codeLens`, the client must provide a command with the i
   }
 }
 ```
+
+## Telemetry
+
+See [TELEMETRY.md](./TELEMETRY.md) for details about what kind of telemetry we collect and how to configure your telemetry settings.
 
 ## tliron/glsp Fork
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,54 @@
+# Telemetry
+
+The Docker Language Server collects telemetry and telemetry collection is **disabled** by default. We collect this telemetry so that we can improve the language server by understanding usage patterns and catching crashes and errors for diagnostic purposes.
+
+## Configuring Telemetry Collection
+
+There are three different telemetry settings in the Docker Language Server.
+
+- `"all"` - all telemetry will be sent
+- `"error"` - send only errors and crash information
+- `"off"` - do not send any telemetry
+
+This configuration can be set in two different ways.
+
+### Initialization
+
+You can include the desired telemetry setting for the language server when sending the initialize `initialize` request from the client to the server. If you include a `telemetry` property inside the `initializationOptions` object in your `initialize` request then the language server will be initialized as such.
+
+```JSONC
+{
+  "clientInfo": {
+      "name": "clientName",
+      "version": "1.2.3"
+  },
+  "initializationOptions": {
+    // you can send enable all telemetry, only send errors, or disable it completely
+    "telemetry": "all" | "error" | "off"
+  }
+}
+```
+
+### Dynamic Configuration
+
+If you want to allow your users to configure their telemetry settings whenever they want, then the client needs to send a `workspace/didChangeConfiguration` to the server notifying it that the `docker.lsp.telemetry` configuration has changed. The server will then send a `workspace/configuration` request to the client asking the client to respond back with what setting (`"all" | "error" | "off"`) should be used.
+
+```mermaid
+sequenceDiagram
+client->>server: workspace/didChangeConfiguration notification
+server->>client: workspace/configuration request
+client->>server: workspace/configuration response
+```
+
+## Telemetry Data Collected
+
+- name and version of the client
+- action id that was executed for resolving a diagnostic
+- name of the function that triggered a crash
+- stack trace of a crash
+- hash of the Git remote of modified files
+- hash of the path of modified files
+
+## Privacy Policy
+
+Read our [privacy policy](https://www.docker.com/legal/docker-privacy-policy/) to learn more about how the information is collected and used.


### PR DESCRIPTION
Created a new, separate file to outline how telemetry is collected and how it can be configured. Also included a section describing what kind of telemetry data we collect.