### PR TITLE
Remove excessive checks to runtime.GOOS

### DIFF
--- a/internal/bake/hcl/diagnosticsCollector.go
+++ b/internal/bake/hcl/diagnosticsCollector.go
@@ -8,9 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
-	"path"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -408,11 +406,7 @@ func ParseDockerfileFromBakeOutput(documentURI uri.URI, target string) (string, 
 			dockerfilePath := *block.Dockerfile
 			dockerfilePath = strings.TrimPrefix(dockerfilePath, "\"")
 			dockerfilePath = strings.TrimSuffix(dockerfilePath, "\"")
-			if runtime.GOOS == "windows" {
-				dockerfilePath, err = filepath.Abs(path.Join(url.Path[1:], fmt.Sprintf("../%v", dockerfilePath)))
-			} else {
-				dockerfilePath, err = filepath.Abs(path.Join(url.Path, fmt.Sprintf("../%v", dockerfilePath)))
-			}
+			dockerfilePath, err = types.AbsolutePath(url, dockerfilePath)
 			if err != nil {
 				return "", nil
 			}

--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -3,6 +3,8 @@ package types
 import (
 	"fmt"
 	"net/url"
+	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -73,4 +75,12 @@ func StripLeadingSlash(folder string) string {
 		return folder[1:]
 	}
 	return folder
+}
+
+func AbsolutePath(documentURL *url.URL, path string) (string, error) {
+	documentPath := documentURL.Path
+	if runtime.GOOS == "windows" {
+		documentPath = documentURL.Path[1:]
+	}
+	return filepath.Abs(filepath.Join(filepath.Dir(documentPath), path))
 }


### PR DESCRIPTION
Refactor the code so that all of the common path manipulation code is centralized in a single function. This helps remove the excessive checks to `runtime.GOOS` which will help make it easier for people to understand the code.