### PR TITLE
Collect telemetry by default

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,6 +1,6 @@
 # Telemetry
 
-The Docker Language Server collects telemetry and telemetry collection is **disabled** by default. We collect this telemetry so that we can improve the language server by understanding usage patterns and catching crashes and errors for diagnostic purposes.
+The Docker Language Server collects telemetry and telemetry collection is **enabled** by default. We collect this telemetry so that we can improve the language server by understanding usage patterns and catching crashes and errors for diagnostic purposes.
 
 ## Configuring Telemetry Collection
 

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -31,7 +31,7 @@ type TelemetryClientImpl struct {
 const telemetryUrl = "https://api.docker.com/events/v1/track"
 
 func NewClient() TelemetryClient {
-	return &TelemetryClientImpl{telemetry: configuration.TelemetrySettingOff}
+	return &TelemetryClientImpl{telemetry: configuration.TelemetrySettingAll}
 }
 
 func (c *TelemetryClientImpl) UpdateTelemetrySetting(value string) {


### PR DESCRIPTION
We will switch to collecting telemetry by default. Any clients connecting to the language server though can always configure it on initialization or dynamically if desired. Please see our `TELEMETRY.md` documentation for the details.