### PR TITLE
Ignore errors related to looking up images

### DIFF
--- a/internal/pkg/buildkit/service_test.go
+++ b/internal/pkg/buildkit/service_test.go
@@ -344,6 +344,16 @@ func TestParse(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "ignore failed to resolve source metadata errors from Docker Hub (https://hub.docker.com/_/docker123)",
+			content:     "FROM docker123",
+			diagnostics: []protocol.Diagnostic{},
+		},
+		{
+			name:        "ignore failed to resolve source metadata errors from Amazon ECR",
+			content:     "FROM aws_account_id.dkr.ecr.region.amazonaws.com/docker123:testtag",
+			diagnostics: []protocol.Diagnostic{},
+		},
 	}
 
 	contextPath := os.TempDir()


### PR DESCRIPTION
It may not be possible to get metadata about an image for any wide variety of reasons (network instability, authentication issues, remote server outage). Should these errors occur, we should ignore them and not surface them to the user as it is more likely for these errors to be outside the user's control. Ideally we should only surface warnings and errors that the user can fix themselves.