### PR TITLE
Add initialization option to suppress some Dockerfile diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Dockerfile
+  - textDocument/publishDiagnostics
+    - introduce a setting to ignore certain diagnostics to not duplicate the ones from the Dockerfile Language Server
+
 ## 0.1.0 - 2025-03-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Use "docker-language-server [command] --help" for more information about a comma
 
 ## Language Server Configuration
 
+### Initialization Options
+
+On startup, the client can include initizliation options on the initial `initialize` request. If the client is also using [rcjsuen/dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server), then some results in `textDocument/publishDiagnostics` will be duplicated across the two language servers. By setting the _experimental_ `dockerfileExperimental.removeOverlappingIssues` to `true`, the Docker Language Server will suppress the duplicated results. Note that this setting may be renamed or removed at any time.
+
+```JSONC
+{
+  "initializationOptions": {
+    "dockerfileExperimental": {
+      "removeOverlappingIssues:": true | false
+    }
+  }
+}
+```
+
 ### Experimental Capabilities
 
 To support `textDocument/codeLens`, the client must provide a command with the id `dockerLspClient.bake.build` for executing the build. If this is supported, the client can define its experimental capabilities as follows. The server will then respond that it supports code lens requests and return results for `textDocument/codeLens` requests for Bake HCL files.

--- a/internal/pkg/buildkit/service.go
+++ b/internal/pkg/buildkit/service.go
@@ -289,12 +289,13 @@ func shouldIgnore(diagnostic protocol.Diagnostic) bool {
 func (c *BuildKitDiagnosticsCollector) CollectDiagnostics(source, workspaceFolder string, doc document.Document, text string) []protocol.Diagnostic {
 	diagnostics, _ := parse(workspaceFolder, source, doc.(document.DockerfileDocument), text)
 	if RemoveOverlappingIssues {
+		filtered := []protocol.Diagnostic{}
 		for i := range diagnostics {
-			if shouldIgnore(diagnostics[i]) {
-				diagnostics = slices.Delete(diagnostics, i, i+1)
-				i--
+			if !shouldIgnore(diagnostics[i]) {
+				filtered = append(filtered, diagnostics[i])
 			}
 		}
+		return filtered
 	}
 	return diagnostics
 }

--- a/internal/pkg/buildkit/service.go
+++ b/internal/pkg/buildkit/service.go
@@ -28,6 +28,11 @@ type BuildOutput struct {
 type BuildKitDiagnosticsCollector struct {
 }
 
+// RemoveOverlappingIssues can be used to decide if diagnostics that
+// overlap with what dockerfile-utils generates should be removed or
+// not.
+var RemoveOverlappingIssues = false
+
 var unknownFlagRegexp *regexp.Regexp
 var commandMajorityFlagRegexp *regexp.Regexp
 
@@ -256,8 +261,41 @@ func parse(contextPath, source string, doc document.DockerfileDocument, content 
 	return lintWithBuildKitBinary(escapedPath, source, doc, content)
 }
 
+func shouldIgnore(diagnostic protocol.Diagnostic) bool {
+	if *diagnostic.Severity == protocol.DiagnosticSeverityError {
+		return true
+	}
+	if diagnostic.Code != nil {
+		if value, ok := diagnostic.Code.Value.(string); ok {
+			switch value {
+			case "ConsistentInstructionCasing":
+				return true
+			case "DuplicateStageName":
+				return true
+			case "MaintainerDeprecated":
+				return true
+			case "MultipleInstructionsDisallowed":
+				return true
+			case "NoEmptyContinuation":
+				return true
+			case "WorkdirRelativePath":
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (c *BuildKitDiagnosticsCollector) CollectDiagnostics(source, workspaceFolder string, doc document.Document, text string) []protocol.Diagnostic {
 	diagnostics, _ := parse(workspaceFolder, source, doc.(document.DockerfileDocument), text)
+	if RemoveOverlappingIssues {
+		for i := range diagnostics {
+			if shouldIgnore(diagnostics[i]) {
+				diagnostics = slices.Delete(diagnostics, i, i+1)
+				i--
+			}
+		}
+	}
 	return diagnostics
 }
 

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/pkg/buildkit"
 	"github.com/docker/docker-language-server/internal/pkg/cli/metadata"
 	"github.com/docker/docker-language-server/internal/telemetry"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
@@ -26,6 +27,12 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 	}
 
 	if clientConfig, ok := params.InitializationOptions.(map[string]any); ok {
+		if settings, ok := clientConfig["dockerfileExperimental"].(map[string]any); ok {
+			if value, ok := settings["removeOverlappingIssues"].(bool); ok {
+				buildkit.RemoveOverlappingIssues = value
+			}
+		}
+
 		if value, ok := clientConfig["telemetry"].(string); ok {
 			s.updateTelemetrySetting(value)
 		}


### PR DESCRIPTION
There are some diagnostics that are flagged by both the Docker Language Server and the Dockerfile Language Server. To provide users of both language servers with a less jarring experience, we have added an (experimental) initialization option on server startup for suppressing the duplicated diagnostics. This will allow clients to run both language servers together without having to worry about showing their users two seemingly different diagnostics that actually mean the same thing.