### PR TITLE
Add missing deferred handlePanic function calls

### DIFF
--- a/internal/pkg/server/didChangeConfiguration.go
+++ b/internal/pkg/server/didChangeConfiguration.go
@@ -18,6 +18,8 @@ func (s *Server) WorkspaceDidChangeConfiguration(ctx *glsp.Context, params *prot
 			scopes := configuration.Documents()
 			if len(scopes) > 0 {
 				go func() {
+					defer s.handlePanic("WorkspaceDidChangeConfiguration")
+
 					s.FetchConfigurations(scopes)
 					s.recomputeDiagnostics()
 				}()

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -247,6 +247,8 @@ func (s *Server) updateTelemetrySetting(value string) {
 // rather than doing it globally.
 func (s *Server) registerFormattingCapability() {
 	go func() {
+		defer s.handlePanic("registerFormattingCapability")
+
 		time.Sleep(registerCapabilityDelay)
 		dockerbakeLanguage := string(protocol.DockerBakeLanguage)
 		dockerbakeDocumentSelctor := protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockerbakeLanguage}}

--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -16,6 +16,8 @@ import (
 func (s *Server) TextDocumentDidOpen(ctx *glsp.Context, params *protocol.DidOpenTextDocumentParams) error {
 	_, _ = s.docs.Write(ctx.Context, uri.URI(params.TextDocument.URI), params.TextDocument.LanguageID, params.TextDocument.Version, []byte(params.TextDocument.Text))
 	go func() {
+		defer s.handlePanic("TextDocumentDidOpen")
+
 		s.FetchConfigurations([]protocol.DocumentUri{params.TextDocument.URI})
 		_ = s.computeDiagnostics(ctx.Context, params.TextDocument.URI, params.TextDocument.Text, params.TextDocument.Version)
 	}()


### PR DESCRIPTION
Including a deferred `handlePanic` function call in the missed goroutines will help us identify and track down errors in the wild.