### PR TITLE
Suggest network attribute values when the cursor is inside the string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to the Docker Language Server will be documented in this fil
 - telemetry
   - records the language identifier of modified files, this will only include Dockerfiles, Bake files, and Compose files
 
+- Docker Bake
+  - textDocument/completion
+    - suggest network attributes when the text cursor is inside of a string
+
 ### Fixed
 
 - Docker Bake

--- a/internal/bake/hcl/completion.go
+++ b/internal/bake/hcl/completion.go
@@ -60,6 +60,20 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 					}
 				}
 
+				if attribute, ok := attributes["network"]; ok && isInsideRange(attribute.Expr.Range(), params.Position) {
+					if expr, ok := attribute.Expr.(*hclsyntax.TemplateExpr); ok && len(expr.Parts) == 1 {
+						if _, ok := expr.Parts[0].(*hclsyntax.LiteralValueExpr); ok {
+							return &protocol.CompletionList{
+								Items: []protocol.CompletionItem{
+									{Label: "default"},
+									{Label: "host"},
+									{Label: "none"},
+								},
+							}, nil
+						}
+					}
+				}
+
 				_, nodes := OpenDockerfile(ctx, manager, dockerfilePath)
 				if nodes != nil {
 					if attribute, ok := attributes["target"]; ok && isInsideRange(attribute.Expr.Range(), params.Position) {

--- a/internal/bake/hcl/completion_test.go
+++ b/internal/bake/hcl/completion_test.go
@@ -264,7 +264,7 @@ func TestCompletion(t *testing.T) {
 			items:     []protocol.CompletionItem{},
 		},
 		{
-			name:      "network attribute suggests default/host/none",
+			name:      "network attribute suggests default/host/none when there is no value",
 			content:   "target \"t\" {\n  network = \n}",
 			line:      1,
 			character: 12,
@@ -304,6 +304,23 @@ func TestCompletion(t *testing.T) {
 						},
 						NewText: "\"none\"",
 					},
+				},
+			},
+		},
+		{
+			name:      "network attribute suggests default/host/none when value is the empty string",
+			content:   "target \"t\" {\n  network = \"\"\n}",
+			line:      1,
+			character: 13,
+			items: []protocol.CompletionItem{
+				{
+					Label: "default",
+				},
+				{
+					Label: "host",
+				},
+				{
+					Label: "none",
 				},
 			},
 		},


### PR DESCRIPTION
Currently, we only suggested `network`'s attribute values if no value has been defined. Now we will suggest those attributes even if the text cursor is inside of the attribute's string value.