### PR TITLE
Remove unnecessary diagnostics calculations by debouncing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,14 +69,14 @@ jobs:
       - run: make build
         working-directory: docker-language-server
 
-      - run: mkdir bin
-        working-directory: vscode-extension
-
       - run: npm install
         working-directory: vscode-extension
 
-      - run: mv ../docker-language-server/docker-language-server-linux-amd64 bin
+      - name: Replace the downloaded binary with the one from the build
         working-directory: vscode-extension
+        run: |
+          rm bin/*
+          mv ../docker-language-server/docker-language-server-linux-amd64 bin
 
       - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
         working-directory: vscode-extension

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,8 +43,51 @@ jobs:
 
       - run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker/lsp:test make test
 
+  integration-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: actions/checkout@v4 (docker/docker-language-server)
+        uses: actions/checkout@v4
+        with:
+          repository: docker/docker-language-server
+          path: docker-language-server
+
+      - name: actions/checkout@v4 (docker/vscode-extension)
+        uses: actions/checkout@v4
+        with:
+          repository: docker/vscode-extension
+          path: vscode-extension
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.23.7"
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - run: make build
+        working-directory: docker-language-server
+
+      - run: mkdir bin
+        working-directory: vscode-extension
+
+      - run: npm install
+        working-directory: vscode-extension
+
+      - run: mv ../docker-language-server/docker-language-server-linux-amd64 bin
+        working-directory: vscode-extension
+
+      - run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+        working-directory: vscode-extension
+
+      - run: xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' npm test
+        working-directory: vscode-extension
+
   upload:
-    needs: build
+    needs:
+      - build
+      - integration-test
     runs-on: ubuntu-latest
 
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- textDocument/publishDiagnostics
+  - stop diagnostics from being sent to the client if a file with errors or warnings were opened by the client and then quickly closed
+
 ## [0.2.0] - 2025-04-03
 
 ### Added
@@ -68,4 +75,5 @@ All notable changes to the Docker Language Server will be documented in this fil
   - textDocument/semanticTokens/full
     - provide syntax highlighting for Bake files
 
+[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.2.0...main
 [0.2.0]: https://github.com/docker/docker-language-server/compare/v0.1.0...v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/docker/docker-language-server
 go 1.23.7
 
 require (
+	github.com/bep/debounce v1.2.1
 	github.com/docker/buildx v0.22.0
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/hashicorp/hcl-lang v0.0.0-20250210193002-b2ec3be7c1b8

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENUpMkpg42fw=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=

--- a/internal/pkg/document/manager.go
+++ b/internal/pkg/document/manager.go
@@ -213,10 +213,15 @@ func (m *Manager) parse(_ context.Context, uri uri.URI, identifier protocol.Lang
 	return changed, nil
 }
 
-func (m *Manager) LockDocument(uri uri.URI) {
+// LockDocument locks the specified document in preparation of
+// publishing diagnostics. False may be returned if the document is not
+// recognized as being opened in the client.
+func (m *Manager) LockDocument(uri uri.URI) bool {
 	if lock, ok := m.diagnosticsProcessing[uri]; ok {
 		lock.mu.Lock()
+		return true
 	}
+	return false
 }
 
 func (m *Manager) UnlockDocument(uri uri.URI) {

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -160,7 +160,7 @@ func (s *Server) recomputeDiagnostics() {
 	for _, uri := range s.docs.Keys() {
 		doc := s.docs.Get(context.Background(), uri)
 		if doc != nil {
-			_ = s.computeDiagnostics(context.Background(), string(uri), string(doc.Input()), 1)
+			s.computeDiagnostics(context.Background(), string(uri))
 		}
 	}
 }

--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -19,7 +19,7 @@ func (s *Server) TextDocumentDidOpen(ctx *glsp.Context, params *protocol.DidOpen
 		defer s.handlePanic("TextDocumentDidOpen")
 
 		s.FetchConfigurations([]protocol.DocumentUri{params.TextDocument.URI})
-		_ = s.computeDiagnostics(ctx.Context, params.TextDocument.URI, params.TextDocument.Text, params.TextDocument.Version)
+		s.computeDiagnostics(ctx.Context, params.TextDocument.URI)
 	}()
 	return nil
 }
@@ -32,12 +32,12 @@ func (s *Server) TextDocumentDidChange(ctx *glsp.Context, params *protocol.DidCh
 	if changeEvent, ok := params.ContentChanges[0].(protocol.TextDocumentContentChangeEvent); ok {
 		changed, _ := s.docs.Overwrite(ctx.Context, uri.URI(params.TextDocument.URI), params.TextDocument.Version, []byte(changeEvent.Text))
 		if changed {
-			return s.computeDiagnostics(ctx.Context, params.TextDocument.URI, changeEvent.Text, params.TextDocument.Version)
+			s.computeDiagnostics(ctx.Context, params.TextDocument.URI)
 		}
 	} else if changeEventWhole, ok := params.ContentChanges[0].(protocol.TextDocumentContentChangeEventWhole); ok {
 		changed, _ := s.docs.Overwrite(ctx.Context, uri.URI(params.TextDocument.URI), params.TextDocument.Version, []byte(changeEventWhole.Text))
 		if changed {
-			return s.computeDiagnostics(ctx.Context, params.TextDocument.URI, changeEventWhole.Text, params.TextDocument.Version)
+			s.computeDiagnostics(ctx.Context, params.TextDocument.URI)
 		}
 	}
 	return nil
@@ -58,7 +58,7 @@ func (s *Server) TextDocumentDidClose(ctx *glsp.Context, params *protocol.DidClo
 	return nil
 }
 
-func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.DocumentUri, text string, version int32) error {
+func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.DocumentUri) {
 	doc := s.docs.Get(ctx, uri.URI(documentURI))
 	folder, absolutePath, relativePath := types.WorkspaceFolder(documentURI, s.workspaceFolders)
 	if folder == "" {
@@ -72,36 +72,29 @@ func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.Do
 		}
 	}
 
-	go func() {
+	s.docs.Queue(ctx, uri.URI(documentURI), func() {
 		defer s.handlePanic("computeDiagnostics")
+		doc := s.docs.Get(context.Background(), uri.URI(documentURI))
 
 		folder = types.StripLeadingSlash(folder)
 		diagnostics := []protocol.Diagnostic{}
 		for _, collector := range s.diagnosticsCollectors {
 			if collector.SupportsLanguageIdentifier(doc.LanguageIdentifier()) {
 				if folder == "" {
-					diagnostics = append(diagnostics, collector.CollectDiagnostics("docker-language-server", os.TempDir(), doc, text)...)
+					diagnostics = append(diagnostics, collector.CollectDiagnostics("docker-language-server", os.TempDir(), doc, string(doc.Input()))...)
 				} else {
-					diagnostics = append(diagnostics, collector.CollectDiagnostics("docker-language-server", folder, doc, text)...)
+					diagnostics = append(diagnostics, collector.CollectDiagnostics("docker-language-server", folder, doc, string(doc.Input()))...)
 				}
 			}
 		}
 
-		knownVersion, err := s.docs.Version(ctx, uri.URI(documentURI))
-		if err != nil {
-			s.client.PublishDiagnostics(context.Background(), protocol.PublishDiagnosticsParams{
-				URI:         documentURI,
-				Diagnostics: diagnostics,
-			})
-		} else if knownVersion == version {
-			s.client.PublishDiagnostics(context.Background(), protocol.PublishDiagnosticsParams{
-				URI:         documentURI,
-				Diagnostics: diagnostics,
-				Version:     &version,
-			})
-		}
-	}()
-	return nil
+		version := doc.Version()
+		s.client.PublishDiagnostics(context.Background(), protocol.PublishDiagnosticsParams{
+			URI:         documentURI,
+			Diagnostics: diagnostics,
+			Version:     &version,
+		})
+	})
 }
 
 // recordAnalysis queues a telemetry event to record that the given path

--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -48,6 +48,8 @@ func (s *Server) TextDocumentDidClose(ctx *glsp.Context, params *protocol.DidClo
 
 	go func() {
 		defer s.handlePanic("TextDocumentDidClose")
+		s.docs.LockDocument(uri.URI(params.TextDocument.URI))
+		defer s.docs.UnlockDocument(uri.URI(params.TextDocument.URI))
 		configuration.Remove(params.TextDocument.URI)
 		// clear out all existing diagnostics when the editor has been closed
 		s.client.PublishDiagnostics(context.Background(), protocol.PublishDiagnosticsParams{
@@ -74,6 +76,8 @@ func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.Do
 
 	s.docs.Queue(ctx, uri.URI(documentURI), func() {
 		defer s.handlePanic("computeDiagnostics")
+		s.docs.LockDocument(uri.URI(documentURI))
+		defer s.docs.UnlockDocument(uri.URI(documentURI))
 		doc := s.docs.Get(context.Background(), uri.URI(documentURI))
 
 		folder = types.StripLeadingSlash(folder)


### PR DESCRIPTION
Originally, every `textDocument/didChange` notification would result in a diagnostic calculation inside of a goroutine. However, this is not ideal as multiple events can come in in a short amount of time when the user is typing. The user is only concerned about the diagnostics of a file when they are done editing. Any diagnostics pertaining to the file when they are still in the middle of typing is not useful as the content of the document has already changed.

By debouncing the diagnostics calculation, we can improve the overall performance of the language server by not wasting CPU cycles calculating something that will simply be discarded.