### PR TITLE
Parse a copy of the document to prevent concurrency issues

### DIFF
--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -74,7 +74,11 @@ func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.Do
 			return
 		}
 		defer s.docs.UnlockDocument(uri.URI(documentURI))
-		doc := s.docs.Get(context.Background(), uri.URI(documentURI))
+		doc, err := s.docs.Read(context.Background(), uri.URI(documentURI))
+		if err != nil {
+			return
+		}
+		defer doc.Close()
 
 		folder = types.StripLeadingSlash(folder)
 		diagnostics := []protocol.Diagnostic{}


### PR DESCRIPTION
The current locks do not prevent modification of the document's internals. Creating and parsing a separate distinct copy of the document will ensure that the rest of the system can continue to interact with the document without it affecting the copy that is being scanned for diagnostics.