### PR TITLE
Ensure the document is not nil before trying to process it

### DIFF
--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -56,6 +56,10 @@ func (s *Server) TextDocumentDidClose(ctx *glsp.Context, params *protocol.DidClo
 
 func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.DocumentUri) {
 	doc := s.docs.Get(ctx, uri.URI(documentURI))
+	if doc == nil {
+		return
+	}
+
 	folder, absolutePath, relativePath := types.WorkspaceFolder(documentURI, s.workspaceFolders)
 	if folder == "" {
 		s.recordAnalysis(doc.LanguageIdentifier(), "unversioned", absolutePath)


### PR DESCRIPTION
If a document is opened and closed very quickly then it will not be in the manager anymore as the diagnostics are processed in a separate goroutine.