### PR TITLE
Queue a function only if the document is being managed

### DIFF
--- a/internal/pkg/document/manager.go
+++ b/internal/pkg/document/manager.go
@@ -120,10 +120,12 @@ func (m *Manager) Queue(ctx context.Context, u uri.URI, fn func()) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	lock := m.diagnosticsProcessing[u]
-	lock.mu.Lock()
-	defer lock.mu.Unlock()
-	lock.queue(fn)
+	if m.LockDocument(u) {
+		defer m.UnlockDocument(u)
+		if lock, ok := m.diagnosticsProcessing[u]; ok {
+			lock.queue(fn)
+		}
+	}
 }
 
 func (m *Manager) Get(ctx context.Context, u uri.URI) Document {


### PR DESCRIPTION
Due to the concurrent nature of the diagnostics processing, it is possible for a document to have been closed before it gets a chance to be processed. To protect against this, we should make sure the document is still being managed before trying to queue it for diagnostics processing.