### PR TITLE
Set CGOENABLED=0 when building the binary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -15,7 +15,7 @@ fi
 
 echo "Building for ${GOOS}-${GOARCH}: ${OUTPUT}"
 
-go build \
+CGO_ENABLED=0 go build \
     -ldflags="-X 'github.com/docker/docker-language-server/internal/pkg/cli/metadata.Version=$VERSION'" \
     -o $OUTPUT \
     ./cmd/docker-language-server


### PR DESCRIPTION
We are observing crashes inside GitHub Codespaces. It seems like it cannot find glibc. Setting `CGO_ENABLED` to `0` should help make the resulting binary more platform independent.

```
[Error - 12:07:18 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
Shutting down server.
[Error - 12:07:18 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
[Error - 12:07:18 AM] Stopping server failed
Error: Client is not running and can't be stopped. It's current state is: starting
    at d.shutdown (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:108000)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:107581)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:273734)
    at d.handleConnectionError (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:114100)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at runNextTicks (node:internal/process/task_queues:64:3)
    at processImmediate (node:internal/timers:454:9)
[Error - 12:07:18 AM] Server initialization failed.
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:18 AM] Docker Language Server client: couldn't create connection to server.
  Message: write EPIPE
  Code: -32099 
[Info  - 12:07:19 AM] Connection to server got closed. Server will restart.
true
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
[Error - 12:07:19 AM] Server process exited with code 1.
[Error - 12:07:19 AM] Server process exited with code 1.
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
Cannot call write after a stream was destroyed
[Error - 12:07:19 AM] Server initialization failed.
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Error - 12:07:19 AM] Docker Language Server client: couldn't create connection to server.
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Error - 12:07:19 AM] Restarting server failed
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Info  - 12:07:19 AM] Connection to server got closed. Server will restart.
true
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
Shutting down server.
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
[Error - 12:07:19 AM] Stopping server failed
Error: Client is not running and can't be stopped. It's current state is: starting
    at d.shutdown (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:108000)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:107581)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:273734)
    at d.handleConnectionError (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:114100)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
[Error - 12:07:19 AM] Server initialization failed.
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:19 AM] Docker Language Server client: couldn't create connection to server.
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:19 AM] Restarting server failed
  Message: write EPIPE
  Code: -32099 
[Info  - 12:07:19 AM] Connection to server got closed. Server will restart.
true
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
[Error - 12:07:19 AM] Server process exited with code 1.
[Error - 12:07:19 AM] Server process exited with code 1.
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
Cannot call write after a stream was destroyed
[Error - 12:07:19 AM] Server initialization failed.
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Error - 12:07:19 AM] Docker Language Server client: couldn't create connection to server.
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Error - 12:07:19 AM] Restarting server failed
  Message: Cannot call write after a stream was destroyed
  Code: -32099 
[Info  - 12:07:19 AM] Connection to server got closed. Server will restart.
true
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
Shutting down server.
[Error - 12:07:19 AM] Client Docker Language Server: connection to server is erroring.
write EPIPE
[Error - 12:07:19 AM] Stopping server failed
Error: Client is not running and can't be stopped. It's current state is: starting
    at d.shutdown (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:108000)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:107581)
    at d.stop (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:273734)
    at d.handleConnectionError (/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/dist/extension.js:1:114100)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at runNextTicks (node:internal/process/task_queues:64:3)
    at processImmediate (node:internal/timers:454:9)
[Error - 12:07:19 AM] Server initialization failed.
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:19 AM] Docker Language Server client: couldn't create connection to server.
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:19 AM] Restarting server failed
  Message: write EPIPE
  Code: -32099 
[Error - 12:07:19 AM] The Docker Language Server server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
/home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/codespace/.vscode-remote/extensions/docker.docker-0.4.2-linux-x64/bin/docker-language-server-linux-amd64)
[Error - 12:07:19 AM] Server process exited with code 1.
```