### PR TITLE
Fix semantic token calculations for single line comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Docker Bake
+  - textDocument/semanticTokens/full
+    - prevent single line comments from crashing the server
+
 ## [0.3.0] - 2025-04-08
 
 ### Fixed

--- a/internal/bake/hcl/semanticTokens.go
+++ b/internal/bake/hcl/semanticTokens.go
@@ -295,7 +295,7 @@ func convertSingleLineCommentToken(bytes []byte, token hclsyntax.Token) lang.Sem
 	endColumn := token.Range.Start.Column + (token.Range.End.Byte - token.Range.Start.Byte)
 	// decrement by one for the \n
 	endColumn--
-	if bytes[token.Range.Start.Byte+endColumn-2] == 13 {
+	if bytes[endColumn-2] == 13 {
 		// decrement by one more for the \r if found (ASCII 13)
 		endColumn--
 	}

--- a/internal/bake/hcl/semanticTokens_test.go
+++ b/internal/bake/hcl/semanticTokens_test.go
@@ -391,6 +391,39 @@ func TestSemanticTokensFull(t *testing.T) {
 				{0, 7, 5, SemanticTokenTypeIndex(TokenType_Keyword), 0},
 			},
 		},
+		{
+			name:    "single line comment after content with no newlines after it",
+			content: "variable \"port\" {default = true} # hello",
+			result: [][]uint32{
+				{0, 0, 8, SemanticTokenTypeIndex(TokenType_Type), 0},
+				{0, 9, 6, SemanticTokenTypeIndex(TokenType_Class), 0},
+				{0, 8, 7, SemanticTokenTypeIndex(TokenType_Property), 0},
+				{0, 10, 4, SemanticTokenTypeIndex(TokenType_Keyword), 0},
+				{0, 6, 7, SemanticTokenTypeIndex(TokenType_Comment), 0},
+			},
+		},
+		{
+			name:    "single line comment after content followed by LF",
+			content: "variable \"port\" {default = true} # hello\n",
+			result: [][]uint32{
+				{0, 0, 8, SemanticTokenTypeIndex(TokenType_Type), 0},
+				{0, 9, 6, SemanticTokenTypeIndex(TokenType_Class), 0},
+				{0, 8, 7, SemanticTokenTypeIndex(TokenType_Property), 0},
+				{0, 10, 4, SemanticTokenTypeIndex(TokenType_Keyword), 0},
+				{0, 6, 7, SemanticTokenTypeIndex(TokenType_Comment), 0},
+			},
+		},
+		{
+			name:    "single line comment after content followed by CRLF",
+			content: "variable \"port\" {default = true} # hello\r\n",
+			result: [][]uint32{
+				{0, 0, 8, SemanticTokenTypeIndex(TokenType_Type), 0},
+				{0, 9, 6, SemanticTokenTypeIndex(TokenType_Class), 0},
+				{0, 8, 7, SemanticTokenTypeIndex(TokenType_Property), 0},
+				{0, 10, 4, SemanticTokenTypeIndex(TokenType_Keyword), 0},
+				{0, 6, 7, SemanticTokenTypeIndex(TokenType_Comment), 0},
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
The following Bake file would crash the server.

Instead of putting on an additional offset from the start of the token, we should just use the `endColumn` as-is as we have already compensated for the start of the column in the initial calculation. It's rather surprising that the original code worked at all... 🤔
```HCL
variable "port" {
  default = 1234 # Default value assigned to `PORT`
}
```
```
panic: runtime error: index out of range [85] with length 71

goroutine 25 [running]:
github.com/docker/docker-language-server/internal/bake/hcl.convertSingleLineCommentToken(...)
	/home/runner/work/lsp-integrations-private/lsp-integrations-private/internal/bake/hcl/semanticTokens.go:298
github.com/docker/docker-language-server/internal/bake/hcl.SemanticTokensFull({0x1614088, 0xc0003767e0}, {0x161c920, 0xc00021cc40}, {0xc00050f400, 0x39})
	/home/runner/work/lsp-integrations-private/lsp-integrations-private/internal/bake/hcl/semanticTokens.go:124 +0x1390
github.com/docker/docker-language-server/internal/pkg/server.(*Server).TextDocumentSemanticTokensFull(0xc0003cc040?, 0xc00033b400, 0xc0003cc040)
	/home/runner/work/lsp-integrations-private/lsp-integrations-private/internal/pkg/server/semanticTokens.go:20 +0x1f5
github.com/docker/docker-language-server/internal/tliron/glsp/protocol.(*Handler).Handle(0xc000183b08, 0xc00033b400)
	/home/runner/work/lsp-integrations-private/lsp-integrations-private/internal/tliron/glsp/protocol/handler.go:675 +0x33b2
github.com/docker/docker-language-server/internal/tliron/glsp/server.(*Server).handle(0xc00030c780, {0x1614088, 0xc0003767e0}, 0xc000326d80, 0xc0003a1bc0)
	/home/runner/work/lsp-integrations-private/lsp-integrations-private/internal/tliron/glsp/server/handler.go:48 +0x267
github.com/sourcegraph/jsonrpc2.(*HandlerWithErrorConfigurer).Handle(0xc0002e7e10, {0x1614088, 0xc0003767e0}, 0xc000326d80, 0xc0003a1bc0)
	/home/runner/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/handler_with_error.go:21 +0x57
github.com/sourcegraph/jsonrpc2.(*Conn).readMessages(0xc000326d80, {0x1614088, 0xc0003767e0})
	/home/runner/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/conn.go:205 +0x2dd
created by github.com/sourcegraph/jsonrpc2.NewConn in goroutine 1
	/home/runner/go/pkg/mod/github.com/sourcegraph/jsonrpc2@v0.2.0/conn.go:62 +0x1e6
[Error - 11:46:27 AM] The Docker Language Server server crashed 5 times in the last 3 minutes. The server will not be restarted. See the output for more information.
[Error - 11:46:27 AM] Server process exited with code 2.
```