### PR TITLE
Recover directly in the glsp handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- refactored the panic handler so that crashes from handling the JSON-RPC messages would no longer cause the language server to crash
+
 ## [0.3.2] - 2025-04-09
 
 ### Fixed

--- a/e2e-tests/semanticTokens_test.go
+++ b/e2e-tests/semanticTokens_test.go
@@ -39,6 +39,39 @@ func TestSemanticTokensFull(t *testing.T) {
 			content: "target {}",
 			result:  []uint32{0, 0, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0},
 		},
+		{
+			name:    "single line comment after content with no newlines after it",
+			content: "variable \"port\" {default = true} # hello",
+			result: []uint32{
+				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			},
+		},
+		{
+			name:    "single line comment after content followed by LF",
+			content: "variable \"port\" {default = true} # hello\n",
+			result: []uint32{
+				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			},
+		},
+		{
+			name:    "single line comment after content followed by CRLF",
+			content: "variable \"port\" {default = true} # hello\r\n",
+			result: []uint32{
+				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/tliron/glsp/protocol/handler.go
+++ b/internal/tliron/glsp/protocol/handler.go
@@ -86,7 +86,7 @@ type Handler struct {
 	TextDocumentInlineValue             TextDocumentInlineValueFunc
 	TextDocumentInlineCompletion        TextDocumentInlineCompletionFunc
 
-	Recover func(method string) error
+	Recover func(method string, recovered interface{}) error
 
 	initialized bool
 	lock        sync.Mutex
@@ -95,9 +95,12 @@ type Handler struct {
 // ([glsp.Handler] interface)
 func (self *Handler) Handle(context *glsp.Context) (r any, validMethod bool, validParams bool, err error) {
 	defer func() {
-		recovered := self.Recover(context.Method)
-		if recovered != nil {
-			err = recovered
+		r := recover()
+		if r != nil {
+			recovered := self.Recover(context.Method, r)
+			if recovered != nil {
+				err = recovered
+			}
 		}
 	}()
 


### PR DESCRIPTION
We noticed an issue where the language server would crash without any telemetry being sent. This was because the initial implementation of the `Recover` handler was not correct since calling `recover()` from the deferred function actually returns `nil`. The panic handling has been refactored so that the deferred function will call `recover()` and then pass that result to the panic handler.