### PR TITLE
Ignore incorrect scalar values in Compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- Compose
+  - textDocument/documentSymbol
+    - prevent scalar values from showing up as a document symbol
+
+## [0.3.3] - 2025-04-09
+
+### Fixed
+
 - refactored the panic handler so that crashes from handling the JSON-RPC messages would no longer cause the language server to crash
 
 ## [0.3.2] - 2025-04-09
@@ -95,7 +103,8 @@ All notable changes to the Docker Language Server will be documented in this fil
   - textDocument/semanticTokens/full
     - provide syntax highlighting for Bake files
 
-[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.3.2...main
+[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.3.3...main
+[0.3.3]: https://github.com/docker/docker-language-server/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/docker/docker-language-server/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/docker/docker-language-server/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/docker/docker-language-server/compare/v0.2.0...v0.3.0

--- a/internal/compose/documentSymbol.go
+++ b/internal/compose/documentSymbol.go
@@ -107,7 +107,8 @@ func DocumentSymbol(ctx context.Context, doc document.ComposeDocument) (result [
 }
 
 func createSymbol(nodes []*yaml.Node, idx int, kind protocol.SymbolKind) (result []any) {
-	for _, service := range nodes[idx].Content {
+	for i := 0; i < len(nodes[idx].Content); i += 2 {
+		service := nodes[idx].Content[i]
 		if service.Value != "" {
 			character := uint32(service.Column - 1)
 			rng := protocol.Range{

--- a/internal/compose/documentSymbol_test.go
+++ b/internal/compose/documentSymbol_test.go
@@ -60,6 +60,26 @@ func TestDocumentSymbol(t *testing.T) {
 			},
 		},
 		{
+			name: "services block with a piped scalar value",
+			content: `services:
+  web: |
+    this is a string`,
+			symbols: []*protocol.DocumentSymbol{
+				{
+					Name: "web",
+					Kind: protocol.SymbolKindClass,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 1, Character: 5},
+					},
+					SelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 2},
+						End:   protocol.Position{Line: 1, Character: 5},
+					},
+				},
+			},
+		},
+		{
 			name: "networks block",
 			content: `networks:
   frontend:`,


### PR DESCRIPTION
If the Compose YAML file has a piped scalar value, the scalar value itself should not be included in the result returned by `textDocument/documentSymbol`.