### PR TITLE
Ignore Markdown files in the builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - "**"
     tags:
       - v*
+    paths-ignore:
+      - '**/*.md'
 
 jobs:
   lint:


### PR DESCRIPTION
We do not need to trigger any builds if we are simply modifying Markdown files.