### PR TITLE
Send an empty array for tokenModifiers instead of null

### DIFF
--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -86,7 +86,8 @@ func initialize(t *testing.T, conn *jsonrpc2.Conn, initializeParams protocol.Ini
 			InlineCompletionProvider: protocol.InlineCompletionOptions{},
 			SemanticTokensProvider: protocol.SemanticTokensOptions{
 				Legend: protocol.SemanticTokensLegend{
-					TokenTypes: hcl.SemanticTokenTypes,
+					TokenModifiers: []string{},
+					TokenTypes:     hcl.SemanticTokenTypes,
 				},
 				Full:  true,
 				Range: false,

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -108,7 +108,8 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 			InlineCompletionProvider: protocol.InlineCompletionOptions{},
 			SemanticTokensProvider: protocol.SemanticTokensOptions{
 				Legend: protocol.SemanticTokensLegend{
-					TokenTypes: hcl.SemanticTokenTypes,
+					TokenModifiers: []string{},
+					TokenTypes:     hcl.SemanticTokenTypes,
 				},
 				Full:  true,
 				Range: false,


### PR DESCRIPTION
The specification expects an array and not a `null` so we need to send an empty array back.

Fixes #54.