### PR TITLE
Resolve Dockerfiles based on a target block's context attribute

### DIFF
--- a/internal/bake/hcl/diagnosticsCollector_test.go
+++ b/internal/bake/hcl/diagnosticsCollector_test.go
@@ -194,6 +194,11 @@ target "lint2" {
 			content:     "target \"child\" {\n  inherits = [\"parent\"]\n  target = \"build\"\n}",
 			diagnostics: []protocol.Diagnostic{},
 		},
+		{
+			name:        "context folder used for looking for the Dockerfile",
+			content:     "target \"backend\" {\n  context = \"./backend\"\n  args = {\n    BACKEND_VAR=\"changed\"\n  }\n}",
+			diagnostics: []protocol.Diagnostic{},
+		},
 	}
 
 	wd, err := os.Getwd()

--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -84,3 +84,11 @@ func AbsolutePath(documentURL *url.URL, path string) (string, error) {
 	}
 	return filepath.Abs(filepath.Join(filepath.Dir(documentPath), path))
 }
+
+func AbsoluteFolder(documentURL *url.URL) (string, error) {
+	documentPath := documentURL.Path
+	if runtime.GOOS == "windows" {
+		documentPath = documentURL.Path[1:]
+	}
+	return filepath.Abs(filepath.Dir(documentPath))
+}

--- a/testdata/diagnostics/backend/Dockerfile
+++ b/testdata/diagnostics/backend/Dockerfile
@@ -1,0 +1,2 @@
+ARG BACKEND_VAR=backend_value
+FROM scratch


### PR DESCRIPTION
We should not be assuming that the Dockerfile always resides in the same folder as the Bake file. If there's a `context` defined then we need to concatenate the folder in the `context` attribute's value with the named Dockerfile.

Fixes #57.