### PR TITLE
 Update inlay hint calculations to consider the block's context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 
 test:
 	gotestsum -- $$(go list ./... | grep -v e2e-tests) -timeout 30s
-	go test $$(go list ./... | grep e2e-tests) -timeout 120s
+	go test $$(go list ./... | grep e2e-tests) -timeout 180s
 
 build-docker-test:
 	docker build -t docker/lsp:test --target test .

--- a/internal/bake/hcl/diagnosticsCollector.go
+++ b/internal/bake/hcl/diagnosticsCollector.go
@@ -211,7 +211,7 @@ func (c *BakeHCLDiagnosticsCollector) CollectDiagnostics(source, workspaceFolder
 				}
 			}
 
-			dockerfilePath, err := evaluateDockerfilePath(block, doc.URI())
+			dockerfilePath, err := EvaluateDockerfilePath(block, doc.URI())
 			if dockerfilePath == "" || err != nil {
 				continue
 			}
@@ -238,9 +238,9 @@ func (c *BakeHCLDiagnosticsCollector) CollectDiagnostics(source, workspaceFolder
 	return diagnostics
 }
 
-// evaluateDockerfilePath uses the output of `docker buildx bake --print`
+// EvaluateDockerfilePath uses the output of `docker buildx bake --print`
 // to identify the location of the Dockerfile that block is using.
-func evaluateDockerfilePath(block *hclsyntax.Block, documentURI uri.URI) (string, error) {
+func EvaluateDockerfilePath(block *hclsyntax.Block, documentURI uri.URI) (string, error) {
 	if len(block.Labels) == 0 {
 		// if the target block has no label we cannot ask Bake to try and print it
 		return "", errors.New("target block has no label")

--- a/internal/bake/hcl/inlayHint.go
+++ b/internal/bake/hcl/inlayHint.go
@@ -25,7 +25,7 @@ func InlayHint(docs *document.Manager, doc document.BakeHCLDocument, rng protoco
 		if block.Type == "target" && len(block.Labels) > 0 {
 			if attribute, ok := block.Body.Attributes["args"]; ok {
 				if expr, ok := attribute.Expr.(*hclsyntax.ObjectConsExpr); ok && len(expr.Items) > 0 {
-					dockerfilePath, err := EvaluateDockerfilePath(block, doc.URI())
+					dockerfilePath, err := EvaluateDockerfilePath(block, doc)
 					if dockerfilePath != "" && err == nil {
 						_, nodes := OpenDockerfile(context.Background(), docs, dockerfilePath)
 						args := map[string]string{}

--- a/testdata/inlayHint/backend/Dockerfile
+++ b/testdata/inlayHint/backend/Dockerfile
@@ -1,0 +1,2 @@
+ARG BACKEND_VAR=backend_value
+FROM scratch


### PR DESCRIPTION
If the `target` block has a `context` attribute, then we should be using it for identifying the Dockerfile to use for looking up ARGs for inlay hint calculations.