### PR TITLE
Resolve Dockerfile correcly for completions if the context attribute is defined

### DIFF
--- a/internal/bake/hcl/completion_test.go
+++ b/internal/bake/hcl/completion_test.go
@@ -356,6 +356,17 @@ func TestCompletion(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "resolve build stage targets from a Dockerfile inside a context folder",
+			content:   "target \"backend\" {\n  context = \"./backend\"\n  target=\"\"\n}",
+			line:      2,
+			character: 10,
+			items: []protocol.CompletionItem{
+				{
+					Label: "nested",
+				},
+			},
+		},
 	}
 
 	bakeFilePath := filepath.Join(completionTestFolderPath, "docker-bake.hcl")

--- a/testdata/completion/backend/Dockerfile
+++ b/testdata/completion/backend/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch AS nested


### PR DESCRIPTION
If the `context` attribute is defined, then we need to use the `context` folder for looking up the Dockerfile instead of simply assuming the file will be in the same folder as the Bake file.