### PR TITLE
Use the Dockerfile in the specified context for calculating definitions

### DIFF
--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -970,6 +970,38 @@ func TestDefinition(t *testing.T) {
 			},
 		},
 		{
+			name:      "args key references Dockerfile ARG variable in a Dockerfile from the context attribute",
+			content:   "target default {\n  context = \"backend\"\n  args = {\n    NESTED_VAR = \"value\"\n  }\n}",
+			line:      3,
+			character: 6,
+			locations: []protocol.Location{
+				{
+					URI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 14},
+					},
+				},
+			},
+			links: []protocol.LocationLink{
+				{
+					OriginSelectionRange: &protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 4},
+						End:   protocol.Position{Line: 3, Character: 14},
+					},
+					TargetURI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+					TargetRange: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 14},
+					},
+					TargetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 14},
+					},
+				},
+			},
+		},
+		{
 			name:      "args key references Dockerfile ARG variable (unquoted key, default value set)",
 			content:   "target default {\n  args = {\n    defined = \"value\"\n  }\n}",
 			line:      2,
@@ -1162,8 +1194,40 @@ func TestDefinition(t *testing.T) {
 			},
 		},
 		{
+			name:      "reference valid stage (target block, no-cache-filter attribute) in a different context folder",
+			content:   "target \"default\" {\n  context = \"backend\"\n  no-cache-filter = [\"stage\"]\n}",
+			line:      2,
+			character: 25,
+			locations: []protocol.Location{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
+					},
+					URI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+				},
+			},
+			links: []protocol.LocationLink{
+				{
+					OriginSelectionRange: &protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 22},
+						End:   protocol.Position{Line: 2, Character: 27},
+					},
+					TargetURI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+					TargetRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
+					},
+					TargetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
+					},
+				},
+			},
+		},
+		{
 			name:      "reference valid stage with target attribute on the right position",
-			content:   "target \"default\" {\ndockerfile = \"Dockerfile\"\ntarget = \"stage\" }",
+			content:   "target \"default\" {\ndockerfile = \"Dockerfile\"\ntarget = \"stage\"\n}",
 			line:      2,
 			character: 13,
 			locations: []protocol.Location{
@@ -1189,6 +1253,38 @@ func TestDefinition(t *testing.T) {
 					TargetSelectionRange: protocol.Range{
 						Start: protocol.Position{Line: 0, Character: 0},
 						End:   protocol.Position{Line: 0, Character: 21},
+					},
+				},
+			},
+		},
+		{
+			name:      "reference valid stage with target attribute on the right position in a different context folder",
+			content:   "target \"default\" {\n  context = \"backend\"\n  dockerfile = \"Dockerfile\"\n  target = \"stage\"\n}",
+			line:      3,
+			character: 13,
+			locations: []protocol.Location{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
+					},
+					URI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+				},
+			},
+			links: []protocol.LocationLink{
+				{
+					OriginSelectionRange: &protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 12},
+						End:   protocol.Position{Line: 3, Character: 17},
+					},
+					TargetURI: fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.Join(definitionTestFolderPath, "backend", "Dockerfile"), "/")),
+					TargetRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
+					},
+					TargetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 21},
 					},
 				},
 			},

--- a/internal/bake/hcl/diagnosticsCollector.go
+++ b/internal/bake/hcl/diagnosticsCollector.go
@@ -244,15 +244,7 @@ func EvaluateDockerfilePath(block *hclsyntax.Block, doc document.Document) (stri
 		// if the target block has no label we cannot ask Bake to try and print it
 		return "", errors.New("target block has no label")
 	}
-
-	if _, ok := block.Body.Attributes["target"]; ok {
-		return ParseDockerfileFromBakeOutput(doc, block.Labels[0])
-	}
-
-	if _, ok := block.Body.Attributes["args"]; ok {
-		return ParseDockerfileFromBakeOutput(doc, block.Labels[0])
-	}
-	return "", nil
+	return ParseDockerfileFromBakeOutput(doc, block.Labels[0])
 }
 
 // checkTargetArgs examines the args attribute of a target block.

--- a/internal/pkg/document/manager.go
+++ b/internal/pkg/document/manager.go
@@ -129,8 +129,6 @@ func (m *Manager) Queue(ctx context.Context, u uri.URI, fn func()) {
 }
 
 func (m *Manager) Get(ctx context.Context, u uri.URI) Document {
-	m.mu.Lock()
-	defer m.mu.Unlock()
 	return m.docs[u]
 }
 

--- a/testdata/definition/backend/Dockerfile
+++ b/testdata/definition/backend/Dockerfile
@@ -1,0 +1,2 @@
+ARG NESTED_VAR
+FROM scratch AS stage


### PR DESCRIPTION
When a `textDocument/definition` request is received for Bake files, we need to use the referenced Dockerfile for determining what the response should be. If a block has a `context` attribute, then we should use that for looking up the Dockerfile instead of assuming that the Dockerfile is in the same folder as the Bake file.