### PR TITLE
Get Bake target tree using Go APIs

### DIFF
--- a/internal/bake/hcl/completion.go
+++ b/internal/bake/hcl/completion.go
@@ -68,7 +68,7 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 				}
 			}
 
-			dockerfilePath, err := EvaluateDockerfilePath(b, document)
+			dockerfilePath, err := document.DockerfileForTarget(b)
 			if dockerfilePath == "" || err != nil {
 				continue
 			}

--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -74,7 +74,7 @@ func Definition(ctx context.Context, definitionLinkSupport bool, manager *docume
 	return nil, nil
 }
 
-func ResolveAttributeValue(ctx context.Context, definitionLinkSupport bool, manager *document.Manager, doc document.Document, body *hclsyntax.Body, documentURI uri.URI, position protocol.Position, sourceBlock *hclsyntax.Block, attribute *hclsyntax.Attribute) any {
+func ResolveAttributeValue(ctx context.Context, definitionLinkSupport bool, manager *document.Manager, doc document.BakeHCLDocument, body *hclsyntax.Body, documentURI uri.URI, position protocol.Position, sourceBlock *hclsyntax.Block, attribute *hclsyntax.Attribute) any {
 	if tupleConsExpr, ok := attribute.Expr.(*hclsyntax.TupleConsExpr); ok {
 		for _, e := range tupleConsExpr.Exprs {
 			if isInsideRange(e.Range(), position) {
@@ -111,7 +111,7 @@ func ResolveAttributeValue(ctx context.Context, definitionLinkSupport bool, mana
 	return ResolveExpression(ctx, definitionLinkSupport, manager, doc, body, documentURI, position, sourceBlock, attribute.Name, attribute.Expr)
 }
 
-func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager *document.Manager, doc document.Document, body *hclsyntax.Body, documentURI uri.URI, position protocol.Position, sourceBlock *hclsyntax.Block, attributeName string, expression hclsyntax.Expression) any {
+func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager *document.Manager, doc document.BakeHCLDocument, body *hclsyntax.Body, documentURI uri.URI, position protocol.Position, sourceBlock *hclsyntax.Block, attributeName string, expression hclsyntax.Expression) any {
 	if templateExpr, ok := expression.(*hclsyntax.TemplateExpr); ok {
 		for _, part := range templateExpr.Parts {
 			if isInsideRange(part.Range(), position) {
@@ -122,7 +122,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 
 	if literalValueExpr, ok := expression.(*hclsyntax.LiteralValueExpr); ok && sourceBlock != nil && sourceBlock.Type == "target" {
 		if attributeName == "no-cache-filter" || attributeName == "target" {
-			dockerfilePath, err := EvaluateDockerfilePath(sourceBlock, doc)
+			dockerfilePath, err := doc.DockerfileForTarget(sourceBlock)
 			if dockerfilePath == "" || err != nil {
 				return nil
 			}
@@ -179,7 +179,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 		for _, item := range objectConsExpression.Items {
 			if isInsideRange(item.KeyExpr.Range(), position) {
 				if attributeName == "args" && sourceBlock.Type == "target" {
-					dockerfilePath, err := EvaluateDockerfilePath(sourceBlock, doc)
+					dockerfilePath, err := doc.DockerfileForTarget(sourceBlock)
 					if dockerfilePath == "" || err != nil {
 						return nil
 					}

--- a/internal/bake/hcl/documentHighlight_test.go
+++ b/internal/bake/hcl/documentHighlight_test.go
@@ -1,12 +1,17 @@
 package hcl
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestDocumentHighlight(t *testing.T) {
@@ -126,9 +131,10 @@ func TestDocumentHighlight(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
 			ranges, err := DocumentHighlight(doc, tc.position)
 			require.NoError(t, err)
 			require.Equal(t, tc.ranges, ranges)

--- a/internal/bake/hcl/documentLink_test.go
+++ b/internal/bake/hcl/documentLink_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestDocumentLink(t *testing.T) {
@@ -81,7 +82,7 @@ func TestDocumentLink(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(bakeFileStringURI), 1, []byte(tc.content))
 			links, err := DocumentLink(context.Background(), bakeFileStringURI, doc)
 			require.NoError(t, err)
 

--- a/internal/bake/hcl/documentSymbol_test.go
+++ b/internal/bake/hcl/documentSymbol_test.go
@@ -2,11 +2,16 @@ package hcl
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestDocumentSymbol(t *testing.T) {
@@ -101,10 +106,11 @@ func TestDocumentSymbol(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
-			symbols, err := DocumentSymbol(context.Background(), "docker-bake.hcl", doc)
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
+			symbols, err := DocumentSymbol(context.Background(), temporaryBakeFile, doc)
 			require.NoError(t, err)
 			var result []any
 			for _, symbol := range tc.symbols {

--- a/internal/bake/hcl/formatting_test.go
+++ b/internal/bake/hcl/formatting_test.go
@@ -1,11 +1,16 @@
 package hcl
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestFormatting(t *testing.T) {
@@ -469,9 +474,10 @@ func TestFormatting(t *testing.T) {
 	}
 	indentations := []string{"\t", "  ", "    "}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
 			for i := range 3 {
 				edits, err := Formatting(doc, options[i])
 				for j := range tc.indentationEdits {
@@ -513,9 +519,10 @@ func TestFormattingCustom(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
 			edits, err := Formatting(doc, protocol.FormattingOptions{
 				protocol.FormattingOptionInsertSpaces: true, protocol.FormattingOptionTabSize: float64(2),
 			})
@@ -538,9 +545,10 @@ func TestFormattingUnchanged(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("docker-bake.hcl", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
 			edits, err := Formatting(doc, protocol.FormattingOptions{
 				protocol.FormattingOptionInsertSpaces: true, protocol.FormattingOptionTabSize: float64(2),
 			})

--- a/internal/bake/hcl/hover_test.go
+++ b/internal/bake/hcl/hover_test.go
@@ -2,12 +2,17 @@ package hcl
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/bake/hcl/parser"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestHover(t *testing.T) {
@@ -221,12 +226,13 @@ func TestHover(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("", 1, []byte(tc.content))
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
 			result, err := Hover(context.Background(), &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
-					TextDocument: protocol.TextDocumentIdentifier{URI: ""},
+					TextDocument: protocol.TextDocumentIdentifier{URI: temporaryBakeFile},
 					Position:     protocol.Position{Line: tc.line, Character: tc.character},
 				},
 			}, doc)

--- a/internal/bake/hcl/inlayHint.go
+++ b/internal/bake/hcl/inlayHint.go
@@ -25,7 +25,7 @@ func InlayHint(docs *document.Manager, doc document.BakeHCLDocument, rng protoco
 		if block.Type == "target" && len(block.Labels) > 0 {
 			if attribute, ok := block.Body.Attributes["args"]; ok {
 				if expr, ok := attribute.Expr.(*hclsyntax.ObjectConsExpr); ok && len(expr.Items) > 0 {
-					dockerfilePath, err := EvaluateDockerfilePath(block, doc)
+					dockerfilePath, err := doc.DockerfileForTarget(block)
 					if dockerfilePath != "" && err == nil {
 						_, nodes := OpenDockerfile(context.Background(), docs, dockerfilePath)
 						args := map[string]string{}

--- a/internal/bake/hcl/semanticTokens_test.go
+++ b/internal/bake/hcl/semanticTokens_test.go
@@ -3,10 +3,14 @@ package hcl
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
 )
 
 func TestSemanticTokensFull(t *testing.T) {
@@ -426,10 +430,11 @@ func TestSemanticTokensFull(t *testing.T) {
 		},
 	}
 
+	temporaryBakeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "docker-bake.hcl")), "/"))
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			doc := document.NewBakeHCLDocument("", 1, []byte(tc.content))
-			tokens, err := SemanticTokensFull(context.Background(), doc, "")
+			doc := document.NewBakeHCLDocument(uri.URI(temporaryBakeFile), 1, []byte(tc.content))
+			tokens, err := SemanticTokensFull(context.Background(), doc, temporaryBakeFile)
 			require.NoError(t, err)
 			testResultOffset := 0
 			for i := 0; i < len(tokens.Data); i += 5 {

--- a/internal/pkg/document/bakeDocument.go
+++ b/internal/pkg/document/bakeDocument.go
@@ -1,10 +1,17 @@
 package document
 
 import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"path/filepath"
 	"sync"
 
+	"github.com/docker/buildx/bake"
 	"github.com/docker/docker-language-server/internal/bake/hcl/parser"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/docker/docker-language-server/internal/types"
 	"github.com/hashicorp/hcl-lang/decoder"
 	"github.com/hashicorp/hcl-lang/lang"
 	"github.com/hashicorp/hcl/v2"
@@ -16,6 +23,12 @@ type BakeHCLDocument interface {
 	Document
 	Decoder() *decoder.PathDecoder
 	File() *hcl.File
+	DockerfileForTarget(block *hclsyntax.Block) (string, error)
+}
+
+type BakePrintOutput struct {
+	Group  map[string]bake.Group  `json:"group,omitempty"`
+	Target map[string]bake.Target `json:"target"`
 }
 
 func NewBakeHCLDocument(u uri.URI, version int32, input []byte) BakeHCLDocument {
@@ -35,9 +48,10 @@ func NewBakeHCLDocument(u uri.URI, version int32, input []byte) BakeHCLDocument 
 
 type bakeHCLDocument struct {
 	document
-	mutex   sync.Mutex
-	decoder *decoder.PathDecoder
-	file    *hcl.File
+	mutex           sync.Mutex
+	decoder         *decoder.PathDecoder
+	file            *hcl.File
+	bakePrintOutput *BakePrintOutput
 }
 
 func (d *bakeHCLDocument) parse(_ bool) bool {
@@ -50,6 +64,7 @@ func (d *bakeHCLDocument) parse(_ bool) bool {
 	pd.PrefillRequiredFields = true
 	d.decoder = pd
 	d.file = file
+	d.extractBakeOutput()
 	return true
 }
 
@@ -67,4 +82,85 @@ func (d *bakeHCLDocument) File() *hcl.File {
 
 func (d *bakeHCLDocument) Decoder() *decoder.PathDecoder {
 	return d.decoder
+}
+
+func (d *bakeHCLDocument) extractBakeOutput() {
+	body, ok := d.File().Body.(*hclsyntax.Body)
+	if !ok {
+		d.bakePrintOutput = nil
+		return
+	}
+
+	targets := []string{}
+	for _, b := range body.Blocks {
+		if len(b.Labels) == 1 {
+			if b.Type == "target" {
+				targets = append(targets, b.Labels[0])
+			}
+		} else {
+			// if the block's label count is not 1 Bake will not parse the file
+			d.bakePrintOutput = nil
+			return
+		}
+	}
+
+	btargets, groups, err := bake.ReadTargets(
+		context.Background(),
+		[]bake.File{{Name: d.uri.Filename(), Data: d.Input()}},
+		targets,
+		nil,
+		nil,
+		nil,
+	)
+	if err != nil {
+		d.bakePrintOutput = nil
+		return
+	}
+
+	checkedGroups := map[string]bake.Group{}
+	checkedTargets := map[string]bake.Target{}
+	for target, value := range btargets {
+		if value != nil {
+			checkedTargets[target] = *value
+		}
+	}
+	for group, value := range groups {
+		if value != nil {
+			checkedGroups[group] = *value
+		}
+	}
+	d.bakePrintOutput = &BakePrintOutput{Group: checkedGroups, Target: checkedTargets}
+}
+
+func (d *bakeHCLDocument) DockerfileForTarget(block *hclsyntax.Block) (string, error) {
+	if d.bakePrintOutput == nil || len(block.Labels) != 1 {
+		return "", errors.New("cannot parse Bake file")
+	}
+
+	url, err := url.Parse(string(d.URI()))
+	if err != nil {
+		return "", fmt.Errorf("LSP client sent invalid URI: %v", string(d.URI()))
+	}
+	contextPath, err := types.AbsoluteFolder(url)
+	if err != nil {
+		return "", fmt.Errorf("LSP client sent invalid URI: %v", string(d.URI()))
+	}
+
+	if block, ok := d.bakePrintOutput.Target[block.Labels[0]]; ok {
+		if block.DockerfileInline != nil {
+			return "", nil
+		} else if block.Context != nil {
+			contextPath = *block.Context
+			contextPath, err = types.AbsolutePath(url, contextPath)
+			if err != nil {
+				return "", nil
+			}
+		}
+
+		if block.Dockerfile != nil {
+			return filepath.Join(contextPath, *block.Dockerfile), nil
+		}
+		return filepath.Join(contextPath, "Dockerfile"), nil
+	}
+	return "", nil
 }


### PR DESCRIPTION
It is extremely costly to run Bake as a separate process when the language client is sending requests to the server non-stop. After reviewing the Bake code, it seems like we can use the `ReadTargets` function to get the same result as running Bake directly. By using this function, we have now improved the performance of the language server significantly and it is now more in line with the original lookup code that was implemented in the beginning of the project.