### PR TITLE
Add nil check before using a ForExpr's CondExpr

### DIFF
--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -170,7 +170,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 			return ResolveExpression(ctx, definitionLinkSupport, manager, doc, body, documentURI, position, sourceBlock, attributeName, forExpr.CollExpr)
 		}
 
-		if isInsideRange(forExpr.CondExpr.Range(), position) {
+		if forExpr.CondExpr != nil && isInsideRange(forExpr.CondExpr.Range(), position) {
 			return ResolveExpression(ctx, definitionLinkSupport, manager, doc, body, documentURI, position, sourceBlock, attributeName, forExpr.CondExpr)
 		}
 	}

--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -906,7 +906,15 @@ func TestDefinition(t *testing.T) {
 			},
 		},
 		{
-			name:      "variable inside a for loop",
+			name:      "variable inside a for loop resolving to upper(var)",
+			content:   "variable varList { default = [\"tag\"] }\ntarget default {\n  tags = [for var in varList : var]\n}",
+			line:      2,
+			character: 16,
+			locations: nil,
+			links:     nil,
+		},
+		{
+			name:      "variable inside a for loop resolving to upper(var)",
 			content:   "variable varList { default = [\"tag\"] }\ntarget default {\n  tags = [for var in varList : upper(var)]\n}",
 			line:      2,
 			character: 24,


### PR DESCRIPTION
Not all for loop expressions in an HCL document will have a conditional expression. We should not error out and panic if the conditional expression is `nil`.