### PR TITLE
Use Get instead of Read to ensure we do not read from disk

### DIFF
--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -78,10 +78,11 @@ func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.Do
 			return
 		}
 		defer s.docs.UnlockDocument(uri.URI(documentURI))
-		doc, err := s.docs.Read(context.Background(), uri.URI(documentURI))
-		if err != nil {
+		doc := s.docs.Get(context.Background(), uri.URI(documentURI))
+		if doc == nil {
 			return
 		}
+		doc = doc.Copy()
 		defer doc.Close()
 
 		folder = types.StripLeadingSlash(folder)


### PR DESCRIPTION
If the file no longer exists in the manager for whatever reasons we do not want to bother reading the file from disk as we should only be reporting errors for files that have been opened in an editor.