### PR TITLE
Support jumping to dependent services in Compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,29 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Bake
+  - textDocument/definition
+    - support code navigation when a single attribute of a target has been reused ([#78](https://github.com/docker/docker-language-server/issues/78))
+- Compose
+  - textDocument/definition
+    - support lookup of services referenced by the short form syntax of `depends_on` ([#67](https://github.com/docker/docker-language-server/issues/67))
+
+### Fixed
+- ensure file validation is skipped if the file has since been closed by the editor ([#79](https://github.com/docker/docker-language-server/issues/79))
+
+## [0.3.7] - 2025-04-21
+
+### Fixed
+- ensure file validation is skipped if the file has since been closed by the editor ([#79](https://github.com/docker/docker-language-server/issues/79))
+
 ## [0.3.6] - 2025-04-18
 
 ### Changed
 - get the JSON structure of a Bake target with Go APIs instead of spawning a separate child process ([#63](https://github.com/docker/docker-language-server/issues/63))
-* Update `moby/buildkit` to v0.21.0 and `docker/buildx` to v0.23.0 ([#64](https://github.com/docker/docker-language-server/issues/64))
+- Update `moby/buildkit` to v0.21.0 and `docker/buildx` to v0.23.0 ([#64](https://github.com/docker/docker-language-server/issues/64))
 
 ### Fixed
 
@@ -129,7 +147,8 @@ All notable changes to the Docker Language Server will be documented in this fil
   - textDocument/semanticTokens/full
     - provide syntax highlighting for Bake files
 
-[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.3.6...main
+[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.3.7...main
+[0.3.7]: https://github.com/docker/docker-language-server/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/docker/docker-language-server/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/docker/docker-language-server/compare/v0.3.4...v0.3.5
 [0.3.4]: https://github.com/docker/docker-language-server/compare/v0.3.3...v0.3.4

--- a/internal/compose/definition.go
+++ b/internal/compose/definition.go
@@ -1,0 +1,98 @@
+package compose
+
+import (
+	"context"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"gopkg.in/yaml.v3"
+)
+
+func Definition(ctx context.Context, definitionLinkSupport bool, doc document.ComposeDocument, params *protocol.DefinitionParams) (any, error) {
+	line := int(params.Position.Line) + 1
+	character := int(params.Position.Character) + 1
+	root := doc.RootNode()
+	if len(root.Content) > 0 {
+		for i := 0; i < len(root.Content[0].Content); i += 2 {
+			switch root.Content[0].Content[i].Value {
+			case "services":
+				for _, service := range root.Content[0].Content[i+1].Content {
+					for j := 0; j < len(service.Content); j += 2 {
+						if service.Content[j].Value == "depends_on" {
+							if service.Content[j+1].Kind == yaml.SequenceNode {
+								for _, dependency := range service.Content[j+1].Content {
+									if dependency.Line == line && dependency.Column <= character && character <= dependency.Column+len(dependency.Value) {
+										serviceRange := ServiceDefinitionRange(root, dependency.Value)
+										if serviceRange == nil {
+											return nil, nil
+										}
+
+										return createDefinitionResult(
+											definitionLinkSupport,
+											*serviceRange,
+											&protocol.Range{
+												Start: protocol.Position{
+													Line:      params.Position.Line,
+													Character: protocol.UInteger(dependency.Column - 1),
+												},
+												End: protocol.Position{
+													Line:      params.Position.Line,
+													Character: protocol.UInteger(dependency.Column + len(dependency.Value) - 1),
+												},
+											},
+											params.TextDocument.URI,
+										), nil
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil, nil
+}
+
+func ServiceDefinitionRange(root yaml.Node, serviceName string) *protocol.Range {
+	for i := 0; i < len(root.Content[0].Content); i += 2 {
+		switch root.Content[0].Content[i].Value {
+		case "services":
+			for _, service := range root.Content[0].Content[i+1].Content {
+				if service.Value == serviceName {
+					return &protocol.Range{
+						Start: protocol.Position{
+							Line:      protocol.UInteger(service.Line) - 1,
+							Character: protocol.UInteger(service.Column - 1),
+						},
+						End: protocol.Position{
+							Line:      protocol.UInteger(service.Line) - 1,
+							Character: protocol.UInteger(service.Column + len(serviceName) - 1),
+						},
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func createDefinitionResult(definitionLinkSupport bool, targetRange protocol.Range, originSelectionRange *protocol.Range, linkURI protocol.URI) any {
+	if !definitionLinkSupport {
+		return []protocol.Location{
+			{
+				Range: targetRange,
+				URI:   linkURI,
+			},
+		}
+	}
+
+	return []protocol.LocationLink{
+		{
+			OriginSelectionRange: originSelectionRange,
+			TargetRange:          targetRange,
+			TargetSelectionRange: targetRange,
+			TargetURI:            linkURI,
+		},
+	}
+}

--- a/internal/compose/definition_test.go
+++ b/internal/compose/definition_test.go
@@ -1,0 +1,133 @@
+package compose
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
+)
+
+func TestDefinition(t *testing.T) {
+	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))
+
+	testCases := []struct {
+		name      string
+		content   string
+		line      uint32
+		character uint32
+		locations any
+		links     any
+	}{
+		{
+			name: "short syntax form of depends_on in services",
+			content: `
+services:
+  web:
+    build: .
+    depends_on:
+      - redis
+  redis:
+    image: redis`,
+			line:      5,
+			character: 11,
+			locations: []protocol.Location{
+				{
+					URI: composeFileURI,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 2},
+						End:   protocol.Position{Line: 6, Character: 7},
+					},
+				},
+			},
+			links: []protocol.LocationLink{
+				{
+					OriginSelectionRange: &protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 8},
+						End:   protocol.Position{Line: 5, Character: 13},
+					},
+					TargetURI: composeFileURI,
+					TargetRange: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 2},
+						End:   protocol.Position{Line: 6, Character: 7},
+					},
+					TargetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 2},
+						End:   protocol.Position{Line: 6, Character: 7},
+					},
+				},
+			},
+		},
+		{
+			name: "short syntax form of depends_on in services finding the right match",
+			content: `
+services:
+  web:
+    build: .
+    depends_on:
+      - postgres
+      - redis
+  postgres:
+    image: postgres
+  redis:
+    image: redis`,
+			line:      6,
+			character: 11,
+			locations: []protocol.Location{
+				{
+					URI: composeFileURI,
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 9, Character: 2},
+						End:   protocol.Position{Line: 9, Character: 7},
+					},
+				},
+			},
+			links: []protocol.LocationLink{
+				{
+					OriginSelectionRange: &protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 8},
+						End:   protocol.Position{Line: 6, Character: 13},
+					},
+					TargetURI: composeFileURI,
+					TargetRange: protocol.Range{
+						Start: protocol.Position{Line: 9, Character: 2},
+						End:   protocol.Position{Line: 9, Character: 7},
+					},
+					TargetSelectionRange: protocol.Range{
+						Start: protocol.Position{Line: 9, Character: 2},
+						End:   protocol.Position{Line: 9, Character: 7},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		u := uri.URI(composeFileURI)
+		doc := document.NewComposeDocument(u, 1, []byte(tc.content))
+		params := protocol.DefinitionParams{
+			TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+				TextDocument: protocol.TextDocumentIdentifier{URI: composeFileURI},
+				Position:     protocol.Position{Line: tc.line, Character: tc.character},
+			},
+		}
+
+		t.Run(fmt.Sprintf("%v (Location)", tc.name), func(t *testing.T) {
+			locations, err := Definition(context.Background(), false, doc, &params)
+			require.NoError(t, err)
+			require.Equal(t, tc.locations, locations)
+		})
+
+		t.Run(fmt.Sprintf("%v (LocationLink)", tc.name), func(t *testing.T) {
+			links, err := Definition(context.Background(), true, doc, &params)
+			require.NoError(t, err)
+			require.Equal(t, tc.links, links)
+		})
+	}
+}

--- a/internal/pkg/server/definition.go
+++ b/internal/pkg/server/definition.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/compose"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -17,6 +18,8 @@ func (s *Server) TextDocumentDefinition(ctx *glsp.Context, params *protocol.Defi
 
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Definition(ctx.Context, s.definitionLinkSupport, s.docs, uri.URI(params.TextDocument.URI), doc.(document.BakeHCLDocument), params.Position)
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+		return compose.Definition(ctx.Context, s.definitionLinkSupport, doc.(document.ComposeDocument), params)
 	}
 	return nil, nil
 }


### PR DESCRIPTION
If the `depends_on` attribute uses the short form array syntax, we can now jump from the dependency reference to the location where the dependency itself has been defined has a service.

Fixes #67.