### PR TITLE
Calculate semantic tokens only for Bake files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Bake
   - textDocument/definition
     - support code navigation when a single attribute of a target has been reused ([#78](https://github.com/docker/docker-language-server/issues/78))
+  - textDocument/semanticTokens/full
+    - ensure only Bake files will respond to a textDocument/semanticTokens/full request ([#84](https://github.com/docker/docker-language-server/issues/84))
 - Compose
   - textDocument/definition
     - support lookup of `services` referenced by the short form syntax of `depends_on` ([#67](https://github.com/docker/docker-language-server/issues/67))

--- a/e2e-tests/semanticTokens_test.go
+++ b/e2e-tests/semanticTokens_test.go
@@ -30,64 +30,79 @@ func TestSemanticTokensFull(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		name    string
-		content string
-		result  []uint32
+		name               string
+		languageIdentifier protocol.LanguageIdentifier
+		content            string
+		result             *protocol.SemanticTokens
 	}{
 		{
-			name:    "target {}",
-			content: "target {}",
-			result:  []uint32{0, 0, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0},
+			name:               "target {}",
+			languageIdentifier: protocol.DockerBakeLanguage,
+			content:            "target {}",
+			result:             &protocol.SemanticTokens{Data: []uint32{0, 0, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0}},
 		},
 		{
-			name:    "single line comment after content with no newlines after it",
-			content: "variable \"port\" {default = true} # hello",
-			result: []uint32{
-				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
-				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
-				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
-				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
-				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			name:               "single line comment after content with no newlines after it",
+			languageIdentifier: protocol.DockerBakeLanguage,
+			content:            "variable \"port\" {default = true} # hello",
+			result: &protocol.SemanticTokens{
+				Data: []uint32{
+					0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+					0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+					0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+					0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+					0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+				},
 			},
 		},
 		{
-			name:    "single line comment after content followed by LF",
-			content: "variable \"port\" {default = true} # hello\n",
-			result: []uint32{
-				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
-				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
-				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
-				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
-				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			name:               "single line comment after content followed by LF",
+			languageIdentifier: protocol.DockerBakeLanguage,
+			content:            "variable \"port\" {default = true} # hello\n",
+			result: &protocol.SemanticTokens{
+				Data: []uint32{
+					0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+					0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+					0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+					0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+					0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+				},
 			},
 		},
 		{
-			name:    "single line comment after content followed by CRLF",
-			content: "variable \"port\" {default = true} # hello\r\n",
-			result: []uint32{
-				0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
-				0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
-				0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
-				0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
-				0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+			name:               "single line comment after content followed by CRLF",
+			languageIdentifier: protocol.DockerBakeLanguage,
+			content:            "variable \"port\" {default = true} # hello\r\n",
+			result: &protocol.SemanticTokens{
+				Data: []uint32{
+					0, 0, 8, hcl.SemanticTokenTypeIndex(hcl.TokenType_Type), 0,
+					0, 9, 6, hcl.SemanticTokenTypeIndex(hcl.TokenType_Class), 0,
+					0, 8, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Property), 0,
+					0, 10, 4, hcl.SemanticTokenTypeIndex(hcl.TokenType_Keyword), 0,
+					0, 6, 7, hcl.SemanticTokenTypeIndex(hcl.TokenType_Comment), 0,
+				},
 			},
+		},
+		{
+			name:               "open dockerfile.hcl (issue 84)",
+			languageIdentifier: protocol.DockerfileLanguage,
+			content:            "FROM scratch",
+			result:             nil,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".hcl", tc.content, "dockerbake")
+			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".hcl", tc.content, tc.languageIdentifier)
 			err := conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
 			require.NoError(t, err)
 
-			var result protocol.SemanticTokens
-			var unset protocol.SemanticTokens
+			var result *protocol.SemanticTokens
 			err = conn.Call(context.Background(), protocol.MethodTextDocumentSemanticTokensFull, protocol.SemanticTokensParams{
 				TextDocument: protocol.TextDocumentIdentifier{URI: didOpen.TextDocument.URI},
 			}, &result)
 			require.NoError(t, err)
-			require.Equal(t, unset.ResultID, result.ResultID)
-			require.Equal(t, tc.result, result.Data)
+			require.Equal(t, tc.result, result)
 		})
 	}
 }

--- a/internal/pkg/server/semanticTokens.go
+++ b/internal/pkg/server/semanticTokens.go
@@ -1,8 +1,6 @@
 package server
 
 import (
-	"strings"
-
 	"github.com/docker/docker-language-server/internal/bake/hcl"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
@@ -16,7 +14,7 @@ func (s *Server) TextDocumentSemanticTokensFull(ctx *glsp.Context, params *proto
 		return nil, err
 	}
 	defer doc.Close()
-	if strings.HasSuffix(string(params.TextDocument.URI), "hcl") {
+	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		result, err := hcl.SemanticTokensFull(ctx.Context, doc.(document.BakeHCLDocument), string(params.TextDocument.URI))
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Files that have an HCL suffix should not be automatically assumed to be a Bake file. We should use the `dockerbake` language identifier instead.