### PR TITLE
Update BakeSchema to Support Both String and Object Types for 'Output' Attribute

### DIFF
--- a/internal/bake/hcl/parser/schema.go
+++ b/internal/bake/hcl/parser/schema.go
@@ -198,7 +198,21 @@ var BakeSchema = &schema.BodySchema{
 					},
 					"output": {
 						IsOptional: true,
-						Constraint: schema.List{Elem: schema.AnyExpression{OfType: cty.String}},
+						Constraint: schema.List{Elem: schema.OneOf{
+							schema.AnyExpression{OfType: cty.String},
+							schema.Object{
+								Attributes: map[string]*schema.AttributeSchema{
+									"type": {
+										IsOptional: true,
+										Constraint: schema.AnyExpression{OfType: cty.String},
+									},
+									"dest": {
+										IsOptional: true,
+										Constraint: schema.AnyExpression{OfType: cty.String},
+									},
+								},
+							},
+						}},
 					},
 					"platforms": {
 						IsOptional: true,

--- a/internal/bake/hcl/parser/schema.go
+++ b/internal/bake/hcl/parser/schema.go
@@ -207,7 +207,7 @@ var BakeSchema = &schema.BodySchema{
 										Constraint: schema.AnyExpression{OfType: cty.String},
 									},
 									"dest": {
-										IsOptional: true,
+										IsOptional: false,
 										Constraint: schema.AnyExpression{OfType: cty.String},
 									},
 								},


### PR DESCRIPTION
This pull request updates the BakeSchema in the schema.go file to enhance the flexibility of the output attribute in the target block. The output attribute now supports both string values and objects with properties like type and dest. This change aligns the schema with the examples provided in the documentation and ensures compatibility with various use cases.
#77 