### PR TITLE
Implement textDocument/completion for Compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
-## [0.4.0] - 2025-04-24
+## [Unreleased]
+
+### Added
+
+- Compose
+  - textDocument/completion
+    - add code completion support based on the JSON schema, extracting out attribute names and enum values ([#86](https://github.com/docker/docker-language-server/issues/86))
+
+## [0.3.8] - 2025-04-24
 
 ### Added
 - Bake
@@ -150,8 +158,8 @@ All notable changes to the Docker Language Server will be documented in this fil
   - textDocument/semanticTokens/full
     - provide syntax highlighting for Bake files
 
-[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.4.0...main
-[0.4.0]: https://github.com/docker/docker-language-server/compare/v0.3.7...v0.4.0
+[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.3.8...main
+[0.3.8]: https://github.com/docker/docker-language-server/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/docker/docker-language-server/compare/v0.3.6...v0.3.7
 [0.3.6]: https://github.com/docker/docker-language-server/compare/v0.3.5...v0.3.6
 [0.3.5]: https://github.com/docker/docker-language-server/compare/v0.3.4...v0.3.5

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/hashicorp/hcl-lang v0.0.0-20250210193002-b2ec3be7c1b8
 	github.com/hashicorp/hcl/v2 v2.23.0
 	github.com/moby/buildkit v0.21.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/sourcegraph/jsonrpc2 v0.2.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/buildx v0.23.0 h1:qoYhuWyZ6PVCrWbkxClLzBWDBCUkyFK6Chjzg6nU+V8=
 github.com/docker/buildx v0.23.0/go.mod h1:y/6Zf/y3Bf0zTWqgg8PuNFATcqnuhFmQuNf4VyrnPtg=
 github.com/docker/cli v28.0.4+incompatible h1:pBJSJeNd9QeIWPjRcV91RVJihd/TXB77q1ef64XEu4A=
@@ -330,6 +332,8 @@ github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sasha-s/go-deadlock v0.3.5 h1:tNCOEEDG6tBqrNDOX35j/7hL5FcFViG6awUGROb2NsU=
 github.com/sasha-s/go-deadlock v0.3.5/go.mod h1:bugP6EGbdGYObIlx7pUZtWqlvo8k9H6vCBBsiChJQ5U=
 github.com/secure-systems-lab/go-securesystemslib v0.4.0 h1:b23VGrQhTA8cN2CbBw7/FulN9fTtqYUdS5+Oxzt+DUE=

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -1,0 +1,134 @@
+package compose
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"gopkg.in/yaml.v3"
+)
+
+func Completion(ctx context.Context, params *protocol.CompletionParams, doc document.ComposeDocument) (*protocol.CompletionList, error) {
+	if params.Position.Character == 0 {
+		items := []protocol.CompletionItem{}
+		for attributeName, schema := range schemaProperties() {
+			item := protocol.CompletionItem{Label: attributeName}
+			if schema.Description != "" {
+				item.Documentation = schema.Description
+			}
+			items = append(items, item)
+		}
+		slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+			return strings.Compare(a.Label, b.Label)
+		})
+		return &protocol.CompletionList{Items: items}, nil
+	}
+
+	lines := strings.Split(string(doc.Input()), "\n")
+	lspLine := int(params.Position.Line)
+	if lspLine >= len(lines) {
+		return nil, nil
+	}
+
+	if strings.HasPrefix(strings.TrimSpace(lines[lspLine]), "#") {
+		return nil, nil
+	}
+
+	root := doc.RootNode()
+	if len(root.Content) == 0 {
+		return nil, nil
+	}
+
+	line := int(lspLine) + 1
+	character := int(params.Position.Character) + 1
+	topLevel, content, _ := nodeStructure(line, root.Content[0].Content)
+	if len(topLevel) == 0 {
+		return nil, nil
+	} else if len(topLevel) == 1 {
+		return nil, nil
+	} else if topLevel[1].Column >= character {
+		return nil, nil
+	} else if len(topLevel) > 2 && topLevel[1].Column < character && character < topLevel[2].Column {
+		topLevel = []*yaml.Node{topLevel[0], topLevel[1]}
+	}
+
+	if topLevel[0].Line == line {
+		return nil, nil
+	}
+
+	for _, childNode := range content.Content {
+		if childNode.Line == line {
+			return nil, nil
+		}
+	}
+
+	items := []protocol.CompletionItem{}
+	for attributeName := range nodeProperties(topLevel, line, character) {
+		items = append(items, protocol.CompletionItem{Label: attributeName})
+	}
+	if len(items) == 0 {
+		return nil, nil
+	}
+	slices.SortFunc(items, func(a, b protocol.CompletionItem) int {
+		return strings.Compare(a.Label, b.Label)
+	})
+	return &protocol.CompletionList{Items: items}, nil
+}
+
+func nodeStructure(line int, rootNodes []*yaml.Node) ([]*yaml.Node, *yaml.Node, bool) {
+	var topLevel *yaml.Node
+	var content *yaml.Node
+	for i := 0; i < len(rootNodes); i += 2 {
+		if rootNodes[i].Line < line {
+			topLevel = rootNodes[i]
+			content = rootNodes[i+1]
+		} else if rootNodes[i].Line == line {
+			return []*yaml.Node{rootNodes[i]}, rootNodes[i+1], true
+		} else if line < rootNodes[i].Line {
+			break
+		}
+	}
+	nodes := []*yaml.Node{topLevel}
+	candidates, subcontent := walkNodes(line, content.Content)
+	nodes = append(nodes, candidates...)
+	if subcontent != nil {
+		content = subcontent
+	}
+	return nodes, content, false
+}
+
+func walkNodes(line int, nodes []*yaml.Node) ([]*yaml.Node, *yaml.Node) {
+	var candidate *yaml.Node
+	var candidateContent *yaml.Node
+	for i := 0; i < len(nodes); i += 2 {
+		if nodes[i].Line < line {
+			candidate = nodes[i]
+			if candidate.Kind == yaml.MappingNode {
+				return walkNodes(line, candidate.Content)
+			}
+			if len(nodes) == i+1 {
+				return []*yaml.Node{candidate}, nil
+			}
+			candidateContent = nodes[i+1]
+		} else if nodes[i].Line == line {
+			if len(nodes) == 1 {
+				return []*yaml.Node{nodes[i]}, nil
+			}
+			return []*yaml.Node{nodes[i]}, nodes[i+1]
+		} else if line < nodes[i].Line {
+			break
+		}
+	}
+	if candidateContent == nil {
+		return []*yaml.Node{}, nil
+	}
+	walked, subcontent := walkNodes(line, candidateContent.Content)
+	candidates := []*yaml.Node{candidate}
+	candidates = append(candidates, walked...)
+	if subcontent != nil {
+		candidateContent = subcontent
+	}
+	return candidates, candidateContent
+}

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -1,0 +1,907 @@
+package compose
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
+)
+
+func TestCompletion(t *testing.T) {
+	testCases := []struct {
+		name      string
+		content   string
+		line      uint32
+		character uint32
+		list      *protocol.CompletionList
+	}{
+		{
+			name: "top level node suggestions",
+			content: `
+configs:
+  test:
+`,
+			line:      3,
+			character: 0,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "configs"},
+					{
+						Documentation: "compose sub-projects to be included.",
+						Label:         "include",
+					},
+					{
+						Documentation: "define the Compose project name, until user defines one explicitly.",
+						Label:         "name",
+					},
+					{Label: "networks"},
+					{Label: "secrets"},
+					{Label: "services"},
+					{
+						Documentation: "declared for backward compatibility, ignored.",
+						Label:         "version",
+					},
+					{Label: "volumes"},
+				},
+			},
+		},
+		{
+			name: "comment prevents suggestions",
+			content: `
+configs:
+  test:
+#`,
+			line:      3,
+			character: 1,
+			list:      nil,
+		},
+		{
+			name: "config attributes",
+			content: `
+configs:
+  test:
+    `,
+			line:      3,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "content"},
+					{Label: "environment"},
+					{Label: "external"},
+					{Label: "file"},
+					{Label: "labels"},
+					{Label: "name"},
+					{Label: "template_driver"},
+				},
+			},
+		},
+		{
+			name: "network attributes",
+			content: `
+networks:
+  test:
+    `,
+			line:      3,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "attachable"},
+					{Label: "driver"},
+					{Label: "driver_opts"},
+					{Label: "enable_ipv4"},
+					{Label: "enable_ipv6"},
+					{Label: "external"},
+					{Label: "internal"},
+					{Label: "ipam"},
+					{Label: "labels"},
+					{Label: "name"},
+				},
+			},
+		},
+		{
+			name: "secret attributes",
+			content: `
+secrets:
+  test:
+    `,
+			line:      3,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "driver"},
+					{Label: "driver_opts"},
+					{Label: "environment"},
+					{Label: "external"},
+					{Label: "file"},
+					{Label: "labels"},
+					{Label: "name"},
+					{Label: "template_driver"},
+				},
+			},
+		},
+		{
+			name: "service attributes",
+			content: `
+services:
+  test:
+    `,
+			line:      3,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "annotations"},
+					{Label: "attach"},
+					{Label: "blkio_config"},
+					{Label: "build"},
+					{Label: "cap_add"},
+					{Label: "cap_drop"},
+					{Label: "cgroup"},
+					{Label: "cgroup_parent"},
+					{Label: "command"},
+					{Label: "configs"},
+					{Label: "container_name"},
+					{Label: "cpu_count"},
+					{Label: "cpu_percent"},
+					{Label: "cpu_period"},
+					{Label: "cpu_quota"},
+					{Label: "cpu_rt_period"},
+					{Label: "cpu_rt_runtime"},
+					{Label: "cpu_shares"},
+					{Label: "cpus"},
+					{Label: "cpuset"},
+					{Label: "credential_spec"},
+					{Label: "depends_on"},
+					{Label: "deploy"},
+					{Label: "develop"},
+					{Label: "device_cgroup_rules"},
+					{Label: "devices"},
+					{Label: "dns"},
+					{Label: "dns_opt"},
+					{Label: "dns_search"},
+					{Label: "domainname"},
+					{Label: "entrypoint"},
+					{Label: "env_file"},
+					{Label: "environment"},
+					{Label: "expose"},
+					{Label: "extends"},
+					{Label: "external_links"},
+					{Label: "extra_hosts"},
+					{Label: "gpus"},
+					{Label: "group_add"},
+					{Label: "healthcheck"},
+					{Label: "hostname"},
+					{Label: "image"},
+					{Label: "init"},
+					{Label: "ipc"},
+					{Label: "isolation"},
+					{Label: "label_file"},
+					{Label: "labels"},
+					{Label: "links"},
+					{Label: "logging"},
+					{Label: "mac_address"},
+					{Label: "mem_limit"},
+					{Label: "mem_reservation"},
+					{Label: "mem_swappiness"},
+					{Label: "memswap_limit"},
+					{Label: "network_mode"},
+					{Label: "networks"},
+					{Label: "oom_kill_disable"},
+					{Label: "oom_score_adj"},
+					{Label: "pid"},
+					{Label: "pids_limit"},
+					{Label: "platform"},
+					{Label: "ports"},
+					{Label: "post_start"},
+					{Label: "pre_stop"},
+					{Label: "privileged"},
+					{Label: "profiles"},
+					{Label: "provider"},
+					{Label: "pull_policy"},
+					{Label: "pull_refresh_after"},
+					{Label: "read_only"},
+					{Label: "restart"},
+					{Label: "runtime"},
+					{Label: "scale"},
+					{Label: "secrets"},
+					{Label: "security_opt"},
+					{Label: "shm_size"},
+					{Label: "stdin_open"},
+					{Label: "stop_grace_period"},
+					{Label: "stop_signal"},
+					{Label: "storage_opt"},
+					{Label: "sysctls"},
+					{Label: "tmpfs"},
+					{Label: "tty"},
+					{Label: "ulimits"},
+					{Label: "user"},
+					{Label: "userns_mode"},
+					{Label: "uts"},
+					{Label: "volumes"},
+					{Label: "volumes_from"},
+					{Label: "working_dir"},
+				},
+			},
+		},
+		{
+			name: "volume attributes",
+			content: `
+volumes:
+  vol:
+    `,
+			line:      3,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "driver"},
+					{Label: "driver_opts"},
+					{Label: "external"},
+					{Label: "labels"},
+					{Label: "name"},
+				},
+			},
+		},
+		{
+			name: "top level attributes show nothing",
+			content: `
+configs:
+volumes: `,
+			line:      2,
+			character: 9,
+			list:      nil,
+		},
+		{
+			name: "node suggestions do not bleed over to the next top level node",
+			content: `
+configs:
+  configA:
+volumes: `,
+			line:      3,
+			character: 9,
+			list:      nil,
+		},
+		{
+			name: "inner attributes of the blkio_config object under service",
+			content: `
+services:
+  postgres:
+    blkio_config:
+      `,
+			line:      4,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "device_read_bps"},
+					{Label: "device_read_iops"},
+					{Label: "device_write_bps"},
+					{Label: "device_write_iops"},
+					{Label: "weight"},
+					{Label: "weight_device"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the deploy object under service",
+			content: `
+services:
+  postgres:
+    deploy:
+      `,
+			line:      4,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "endpoint_mode"},
+					{Label: "labels"},
+					{Label: "mode"},
+					{Label: "placement"},
+					{Label: "replicas"},
+					{Label: "resources"},
+					{Label: "restart_policy"},
+					{Label: "rollback_config"},
+					{Label: "update_config"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the deploy/resources object under service",
+			content: `
+services:
+  postgres:
+    deploy:
+      resources:
+        `,
+			line:      5,
+			character: 8,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "limits"},
+					{Label: "reservations"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the develop object under service",
+			content: `
+services:
+  postgres:
+    develop:
+      `,
+			line:      4,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "watch"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the build object under service",
+			content: `
+services:
+  postgres:
+    build:
+      `,
+			line:      4,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "additional_contexts"},
+					{Label: "args"},
+					{Label: "cache_from"},
+					{Label: "cache_to"},
+					{Label: "context"},
+					{Label: "dockerfile"},
+					{Label: "dockerfile_inline"},
+					{Label: "entitlements"},
+					{Label: "extra_hosts"},
+					{Label: "isolation"},
+					{Label: "labels"},
+					{Label: "network"},
+					{Label: "no_cache"},
+					{Label: "platforms"},
+					{Label: "privileged"},
+					{Label: "pull"},
+					{Label: "secrets"},
+					{Label: "shm_size"},
+					{Label: "ssh"},
+					{Label: "tags"},
+					{Label: "target"},
+					{Label: "ulimits"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the blkio_config object under service with weight already present",
+			content: `
+services:
+  postgres:
+    blkio_config:
+      weight: 0
+      `,
+			line:      5,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "device_read_bps"},
+					{Label: "device_read_iops"},
+					{Label: "device_write_bps"},
+					{Label: "device_write_iops"},
+					{Label: "weight"},
+					{Label: "weight_device"},
+				},
+			},
+		},
+		{
+			name: "inner attributes of the ulimits object under service",
+			content: `
+services:
+  test:
+    build:
+      ulimits:
+        abc:
+          `,
+			line:      6,
+			character: 10,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "hard"},
+					{Label: "soft"},
+				},
+			},
+		},
+		{
+			name: "indentation considered for a sibling of a service's attribute",
+			content: `
+services:
+  postgres:
+    image: alpine
+    `,
+			line:      4,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "annotations"},
+					{Label: "attach"},
+					{Label: "blkio_config"},
+					{Label: "build"},
+					{Label: "cap_add"},
+					{Label: "cap_drop"},
+					{Label: "cgroup"},
+					{Label: "cgroup_parent"},
+					{Label: "command"},
+					{Label: "configs"},
+					{Label: "container_name"},
+					{Label: "cpu_count"},
+					{Label: "cpu_percent"},
+					{Label: "cpu_period"},
+					{Label: "cpu_quota"},
+					{Label: "cpu_rt_period"},
+					{Label: "cpu_rt_runtime"},
+					{Label: "cpu_shares"},
+					{Label: "cpus"},
+					{Label: "cpuset"},
+					{Label: "credential_spec"},
+					{Label: "depends_on"},
+					{Label: "deploy"},
+					{Label: "develop"},
+					{Label: "device_cgroup_rules"},
+					{Label: "devices"},
+					{Label: "dns"},
+					{Label: "dns_opt"},
+					{Label: "dns_search"},
+					{Label: "domainname"},
+					{Label: "entrypoint"},
+					{Label: "env_file"},
+					{Label: "environment"},
+					{Label: "expose"},
+					{Label: "extends"},
+					{Label: "external_links"},
+					{Label: "extra_hosts"},
+					{Label: "gpus"},
+					{Label: "group_add"},
+					{Label: "healthcheck"},
+					{Label: "hostname"},
+					{Label: "image"},
+					{Label: "init"},
+					{Label: "ipc"},
+					{Label: "isolation"},
+					{Label: "label_file"},
+					{Label: "labels"},
+					{Label: "links"},
+					{Label: "logging"},
+					{Label: "mac_address"},
+					{Label: "mem_limit"},
+					{Label: "mem_reservation"},
+					{Label: "mem_swappiness"},
+					{Label: "memswap_limit"},
+					{Label: "network_mode"},
+					{Label: "networks"},
+					{Label: "oom_kill_disable"},
+					{Label: "oom_score_adj"},
+					{Label: "pid"},
+					{Label: "pids_limit"},
+					{Label: "platform"},
+					{Label: "ports"},
+					{Label: "post_start"},
+					{Label: "pre_stop"},
+					{Label: "privileged"},
+					{Label: "profiles"},
+					{Label: "provider"},
+					{Label: "pull_policy"},
+					{Label: "pull_refresh_after"},
+					{Label: "read_only"},
+					{Label: "restart"},
+					{Label: "runtime"},
+					{Label: "scale"},
+					{Label: "secrets"},
+					{Label: "security_opt"},
+					{Label: "shm_size"},
+					{Label: "stdin_open"},
+					{Label: "stop_grace_period"},
+					{Label: "stop_signal"},
+					{Label: "storage_opt"},
+					{Label: "sysctls"},
+					{Label: "tmpfs"},
+					{Label: "tty"},
+					{Label: "ulimits"},
+					{Label: "user"},
+					{Label: "userns_mode"},
+					{Label: "uts"},
+					{Label: "volumes"},
+					{Label: "volumes_from"},
+					{Label: "working_dir"},
+				},
+			},
+		},
+		{
+			name: "indentation considered and does not suggest any items needing a name",
+			content: `
+services:
+  postgres:
+    blkio_config:
+      weight: 0
+  `,
+			line:      5,
+			character: 2,
+			list:      nil,
+		},
+		{
+			name: "indentation considered when suggesting child items",
+			content: `
+services:
+  postgres:
+    blkio_config:
+      weight: 0
+    `,
+			line:      5,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "annotations"},
+					{Label: "attach"},
+					{Label: "blkio_config"},
+					{Label: "build"},
+					{Label: "cap_add"},
+					{Label: "cap_drop"},
+					{Label: "cgroup"},
+					{Label: "cgroup_parent"},
+					{Label: "command"},
+					{Label: "configs"},
+					{Label: "container_name"},
+					{Label: "cpu_count"},
+					{Label: "cpu_percent"},
+					{Label: "cpu_period"},
+					{Label: "cpu_quota"},
+					{Label: "cpu_rt_period"},
+					{Label: "cpu_rt_runtime"},
+					{Label: "cpu_shares"},
+					{Label: "cpus"},
+					{Label: "cpuset"},
+					{Label: "credential_spec"},
+					{Label: "depends_on"},
+					{Label: "deploy"},
+					{Label: "develop"},
+					{Label: "device_cgroup_rules"},
+					{Label: "devices"},
+					{Label: "dns"},
+					{Label: "dns_opt"},
+					{Label: "dns_search"},
+					{Label: "domainname"},
+					{Label: "entrypoint"},
+					{Label: "env_file"},
+					{Label: "environment"},
+					{Label: "expose"},
+					{Label: "extends"},
+					{Label: "external_links"},
+					{Label: "extra_hosts"},
+					{Label: "gpus"},
+					{Label: "group_add"},
+					{Label: "healthcheck"},
+					{Label: "hostname"},
+					{Label: "image"},
+					{Label: "init"},
+					{Label: "ipc"},
+					{Label: "isolation"},
+					{Label: "label_file"},
+					{Label: "labels"},
+					{Label: "links"},
+					{Label: "logging"},
+					{Label: "mac_address"},
+					{Label: "mem_limit"},
+					{Label: "mem_reservation"},
+					{Label: "mem_swappiness"},
+					{Label: "memswap_limit"},
+					{Label: "network_mode"},
+					{Label: "networks"},
+					{Label: "oom_kill_disable"},
+					{Label: "oom_score_adj"},
+					{Label: "pid"},
+					{Label: "pids_limit"},
+					{Label: "platform"},
+					{Label: "ports"},
+					{Label: "post_start"},
+					{Label: "pre_stop"},
+					{Label: "privileged"},
+					{Label: "profiles"},
+					{Label: "provider"},
+					{Label: "pull_policy"},
+					{Label: "pull_refresh_after"},
+					{Label: "read_only"},
+					{Label: "restart"},
+					{Label: "runtime"},
+					{Label: "scale"},
+					{Label: "secrets"},
+					{Label: "security_opt"},
+					{Label: "shm_size"},
+					{Label: "stdin_open"},
+					{Label: "stop_grace_period"},
+					{Label: "stop_signal"},
+					{Label: "storage_opt"},
+					{Label: "sysctls"},
+					{Label: "tmpfs"},
+					{Label: "tty"},
+					{Label: "ulimits"},
+					{Label: "user"},
+					{Label: "userns_mode"},
+					{Label: "uts"},
+					{Label: "volumes"},
+					{Label: "volumes_from"},
+					{Label: "working_dir"},
+				},
+			},
+		},
+		{
+			name: "invalid services as an array",
+			content: `
+services:
+  - `,
+			line:      2,
+			character: 4,
+			list:      nil,
+		},
+		{
+			name: "properties of an embedded object with a custom name",
+			content: `
+services:
+  test:
+    networks:
+      abc:
+        `,
+			line:      5,
+			character: 8,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "aliases"},
+					{Label: "driver_opts"},
+					{Label: "gw_priority"},
+					{Label: "interface_name"},
+					{Label: "ipv4_address"},
+					{Label: "ipv6_address"},
+					{Label: "link_local_ips"},
+					{Label: "mac_address"},
+					{Label: "priority"},
+				},
+			},
+		},
+		{
+			name: "oneOf results of a service object's networks attribute",
+			content: `
+services:
+  test:
+    networks:
+      `,
+			line:      4,
+			character: 6,
+			list:      nil,
+		},
+		{
+			name: "sibling attributes shown after an array of items",
+			content: `
+services:
+  test:
+    networks:
+    - testNetwork
+    `,
+			line:      5,
+			character: 4,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "annotations"},
+					{Label: "attach"},
+					{Label: "blkio_config"},
+					{Label: "build"},
+					{Label: "cap_add"},
+					{Label: "cap_drop"},
+					{Label: "cgroup"},
+					{Label: "cgroup_parent"},
+					{Label: "command"},
+					{Label: "configs"},
+					{Label: "container_name"},
+					{Label: "cpu_count"},
+					{Label: "cpu_percent"},
+					{Label: "cpu_period"},
+					{Label: "cpu_quota"},
+					{Label: "cpu_rt_period"},
+					{Label: "cpu_rt_runtime"},
+					{Label: "cpu_shares"},
+					{Label: "cpus"},
+					{Label: "cpuset"},
+					{Label: "credential_spec"},
+					{Label: "depends_on"},
+					{Label: "deploy"},
+					{Label: "develop"},
+					{Label: "device_cgroup_rules"},
+					{Label: "devices"},
+					{Label: "dns"},
+					{Label: "dns_opt"},
+					{Label: "dns_search"},
+					{Label: "domainname"},
+					{Label: "entrypoint"},
+					{Label: "env_file"},
+					{Label: "environment"},
+					{Label: "expose"},
+					{Label: "extends"},
+					{Label: "external_links"},
+					{Label: "extra_hosts"},
+					{Label: "gpus"},
+					{Label: "group_add"},
+					{Label: "healthcheck"},
+					{Label: "hostname"},
+					{Label: "image"},
+					{Label: "init"},
+					{Label: "ipc"},
+					{Label: "isolation"},
+					{Label: "label_file"},
+					{Label: "labels"},
+					{Label: "links"},
+					{Label: "logging"},
+					{Label: "mac_address"},
+					{Label: "mem_limit"},
+					{Label: "mem_reservation"},
+					{Label: "mem_swappiness"},
+					{Label: "memswap_limit"},
+					{Label: "network_mode"},
+					{Label: "networks"},
+					{Label: "oom_kill_disable"},
+					{Label: "oom_score_adj"},
+					{Label: "pid"},
+					{Label: "pids_limit"},
+					{Label: "platform"},
+					{Label: "ports"},
+					{Label: "post_start"},
+					{Label: "pre_stop"},
+					{Label: "privileged"},
+					{Label: "profiles"},
+					{Label: "provider"},
+					{Label: "pull_policy"},
+					{Label: "pull_refresh_after"},
+					{Label: "read_only"},
+					{Label: "restart"},
+					{Label: "runtime"},
+					{Label: "scale"},
+					{Label: "secrets"},
+					{Label: "security_opt"},
+					{Label: "shm_size"},
+					{Label: "stdin_open"},
+					{Label: "stop_grace_period"},
+					{Label: "stop_signal"},
+					{Label: "storage_opt"},
+					{Label: "sysctls"},
+					{Label: "tmpfs"},
+					{Label: "tty"},
+					{Label: "ulimits"},
+					{Label: "user"},
+					{Label: "userns_mode"},
+					{Label: "uts"},
+					{Label: "volumes"},
+					{Label: "volumes_from"},
+					{Label: "working_dir"},
+				},
+			},
+		},
+		{
+			name: "properties of a volume array item's sibling attributes under a service object",
+			content: `
+services:
+  test:
+    image: alpine
+    volumes:
+      - type: bind
+        `,
+			line:      6,
+			character: 8,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "bind"},
+					{Label: "consistency"},
+					{Label: "image"},
+					{Label: "read_only"},
+					{Label: "source"},
+					{Label: "target"},
+					{Label: "tmpfs"},
+					{Label: "type"},
+					{Label: "volume"},
+				},
+			},
+		},
+		{
+			name: "properties of a volume array item's bind attributes under a service object",
+			content: `
+services:
+  test:
+    image: alpine
+    volumes:
+      - type: bind
+        bind:
+          `,
+			line:      7,
+			character: 10,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "create_host_path"},
+					{Label: "propagation"},
+					{Label: "recursive"},
+					{Label: "selinux"},
+				},
+			},
+		},
+		{
+			name: "properties of a volume array item's volume attributes under a service object",
+			content: `
+services:
+  test:
+    image: alpine
+    volumes:
+      - type: bind
+        volume:
+          `,
+			line:      7,
+			character: 10,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "labels"},
+					{Label: "nocopy"},
+					{Label: "subpath"},
+				},
+			},
+		},
+		{
+			name: "enum properties for a string attribute is suggested",
+			content: `
+services:
+  test:
+    volumes:
+      - type: bind
+        bind:
+          selinux: `,
+			line:      6,
+			character: 19,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{Label: "Z"},
+					{Label: "z"},
+				},
+			},
+		},
+		{
+			name: "nothing suggested for an arbitrary string attribute's value",
+			content: `
+services:
+  test:
+    volumes:
+      - type: bind
+        bind:
+          propagation:`,
+			line:      6,
+			character: 22,
+			list:      nil,
+		},
+	}
+
+	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := document.NewComposeDocument(uri.URI(composeFileURI), 1, []byte(tc.content))
+			list, err := Completion(context.Background(), &protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: composeFileURI},
+					Position:     protocol.Position{Line: tc.line, Character: tc.character},
+				},
+			}, doc)
+			require.NoError(t, err)
+			if tc.list == nil {
+				require.Nil(t, list)
+			} else {
+				require.Equal(t, tc.list, list)
+			}
+		})
+	}
+}

--- a/internal/compose/compose-spec.json
+++ b/internal/compose/compose-spec.json
@@ -1,0 +1,1025 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "compose_spec.json",
+  "type": "object",
+  "title": "Compose Specification",
+  "description": "The Compose file is a YAML file defining a multi-containers based application.",
+
+  "properties": {
+    "version": {
+      "type": "string",
+      "description": "declared for backward compatibility, ignored."
+    },
+
+    "name": {
+      "type": "string",
+      "description": "define the Compose project name, until user defines one explicitly."
+    },
+
+    "include": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/include"
+      },
+      "description": "compose sub-projects to be included."
+    },
+
+    "services": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/service"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "networks": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/network"
+        }
+      }
+    },
+
+    "volumes": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/volume"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "secrets": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/secret"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "configs": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-zA-Z0-9._-]+$": {
+          "$ref": "#/definitions/config"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "patternProperties": {"^x-": {}},
+  "additionalProperties": false,
+
+  "definitions": {
+
+    "service": {
+      "type": "object",
+
+      "properties": {
+        "develop": {"$ref": "#/definitions/development"},
+        "deploy": {"$ref": "#/definitions/deployment"},
+        "annotations": {"$ref": "#/definitions/list_or_dict"},
+        "attach": {"type": ["boolean", "string"]},
+        "build": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+              "properties": {
+                "context": {"type": "string"},
+                "dockerfile": {"type": "string"},
+                "dockerfile_inline": {"type": "string"},
+                "entitlements": {"type": "array", "items": {"type": "string"}},
+                "args": {"$ref": "#/definitions/list_or_dict"},
+                "ssh": {"$ref": "#/definitions/list_or_dict"},
+                "labels": {"$ref": "#/definitions/list_or_dict"},
+                "cache_from": {"type": "array", "items": {"type": "string"}},
+                "cache_to": {"type": "array", "items": {"type": "string"}},
+                "no_cache": {"type": ["boolean", "string"]},
+                "additional_contexts": {"$ref": "#/definitions/list_or_dict"},
+                "network": {"type": "string"},
+                "pull": {"type": ["boolean", "string"]},
+                "target": {"type": "string"},
+                "shm_size": {"type": ["integer", "string"]},
+                "extra_hosts": {"$ref": "#/definitions/extra_hosts"},
+                "isolation": {"type": "string"},
+                "privileged": {"type": ["boolean", "string"]},
+                "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+                "tags": {"type": "array", "items": {"type": "string"}},
+                "ulimits": {"$ref": "#/definitions/ulimits"},
+                "platforms": {"type": "array", "items": {"type": "string"}}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            }
+          ]
+        },
+        "blkio_config": {
+          "type": "object",
+          "properties": {
+            "device_read_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_read_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_bps": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "device_write_iops": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_limit"}
+            },
+            "weight": {"type": ["integer", "string"]},
+            "weight_device": {
+              "type": "array",
+              "items": {"$ref": "#/definitions/blkio_weight"}
+            }
+          },
+          "additionalProperties": false
+        },
+        "cap_add": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cap_drop": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "cgroup": {"type": "string", "enum": ["host", "private"]},
+        "cgroup_parent": {"type": "string"},
+        "command": {"$ref": "#/definitions/command"},
+        "configs": {"$ref": "#/definitions/service_config_or_secret"},
+        "container_name": {"type": "string"},
+        "cpu_count": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": 0}
+        ]},
+        "cpu_percent": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": 0, "maximum": 100}
+        ]},
+        "cpu_shares": {"type": ["number", "string"]},
+        "cpu_quota": {"type": ["number", "string"]},
+        "cpu_period": {"type": ["number", "string"]},
+        "cpu_rt_period": {"type": ["number", "string"]},
+        "cpu_rt_runtime": {"type": ["number", "string"]},
+        "cpus": {"type": ["number", "string"]},
+        "cpuset": {"type": "string"},
+        "credential_spec": {
+          "type": "object",
+          "properties": {
+            "config": {"type": "string"},
+            "file": {"type": "string"},
+            "registry": {"type": "string"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "depends_on": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "patternProperties": {"^x-": {}},
+                  "properties": {
+                    "restart": {"type": ["boolean", "string"]},
+                    "required": {
+                      "type":  "boolean",
+                      "default": true
+                    },
+                    "condition": {
+                      "type": "string",
+                      "enum": ["service_started", "service_healthy", "service_completed_successfully"]
+                    }
+                  },
+                  "required": ["condition"]
+                }
+              }
+            }
+          ]
+        },
+        "device_cgroup_rules": {"$ref": "#/definitions/list_of_strings"},
+        "devices": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["source"],
+                "properties": {
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "permissions": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          }
+        },
+        "dns": {"$ref": "#/definitions/string_or_list"},
+        "dns_opt": {"type": "array","items": {"type": "string"}, "uniqueItems": true},
+        "dns_search": {"$ref": "#/definitions/string_or_list"},
+        "domainname": {"type": "string"},
+        "entrypoint": {"$ref": "#/definitions/command"},
+        "env_file": {"$ref": "#/definitions/env_file"},
+        "label_file": {"$ref": "#/definitions/label_file"},
+        "environment": {"$ref": "#/definitions/list_or_dict"},
+
+        "expose": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"]
+          },
+          "uniqueItems": true
+        },
+        "extends": {
+          "oneOf": [
+            {"type": "string"},
+            {
+              "type": "object",
+
+              "properties": {
+                "service": {"type": "string"},
+                "file": {"type": "string"}
+              },
+              "required": ["service"],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "provider": {
+          "type": "object",
+          "properties": {
+            "type": {"type": "string"},
+            "options": {
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {"type": ["string", "number", "null"]}
+              }
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "external_links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "extra_hosts": {"$ref": "#/definitions/extra_hosts"},
+        "gpus": {"$ref": "#/definitions/gpus"},
+        "group_add": {
+          "type": "array",
+          "items": {
+            "type": ["string", "number"]
+          },
+          "uniqueItems": true
+        },
+        "healthcheck": {"$ref": "#/definitions/healthcheck"},
+        "hostname": {"type": "string"},
+        "image": {"type": "string"},
+        "init": {"type": ["boolean", "string"]},
+        "ipc": {"type": "string"},
+        "isolation": {"type": "string"},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "links": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "logging": {
+          "type": "object",
+          "properties": {
+            "driver": {"type": "string"},
+            "options": {
+              "type": "object",
+              "patternProperties": {
+                "^.+$": {"type": ["string", "number", "null"]}
+              }
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "mac_address": {"type": "string"},
+        "mem_limit": {"type": ["number", "string"]},
+        "mem_reservation": {"type": ["string", "integer"]},
+        "mem_swappiness": {"type": ["integer", "string"]},
+        "memswap_limit": {"type": ["number", "string"]},
+        "network_mode": {"type": "string"},
+        "networks": {
+          "oneOf": [
+            {"$ref": "#/definitions/list_of_strings"},
+            {
+              "type": "object",
+              "patternProperties": {
+                "^[a-zA-Z0-9._-]+$": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "aliases": {"$ref": "#/definitions/list_of_strings"},
+                        "interface_name": {"type": "string"},
+                        "ipv4_address": {"type": "string"},
+                        "ipv6_address": {"type": "string"},
+                        "link_local_ips": {"$ref": "#/definitions/list_of_strings"},
+                        "mac_address": {"type": "string"},
+                        "driver_opts": {
+                          "type": "object",
+                          "patternProperties": {
+                            "^.+$": {"type": ["string", "number"]}
+                          }
+                        },
+                        "priority": {"type": "number"},
+                        "gw_priority": {"type": "number"}
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {"^x-": {}}
+                    },
+                    {"type": "null"}
+                  ]
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "oom_kill_disable": {"type": ["boolean", "string"]},
+        "oom_score_adj": {"oneOf": [
+          {"type": "string"},
+          {"type": "integer", "minimum": -1000, "maximum": 1000}
+        ]},
+        "pid": {"type": ["string", "null"]},
+        "pids_limit": {"type": ["number", "string"]},
+        "platform": {"type": "string"},
+        "ports": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "number"},
+              {"type": "string"},
+              {
+                "type": "object",
+                "properties": {
+                  "name": {"type": "string"},
+                  "mode": {"type": "string"},
+                  "host_ip": {"type": "string"},
+                  "target": {"type": ["integer", "string"]},
+                  "published": {"type": ["string", "integer"]},
+                  "protocol": {"type": "string"},
+                  "app_protocol": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "post_start": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "pre_stop": {"type": "array", "items": {"$ref": "#/definitions/service_hook"}},
+        "privileged": {"type": ["boolean", "string"]},
+        "profiles": {"$ref": "#/definitions/list_of_strings"},
+        "pull_policy": {"type": "string",
+          "pattern": "always|never|build|if_not_present|missing|refresh|daily|weekly|every_([0-9]+[wdhms])+"
+        },
+        "pull_refresh_after": {"type": "string"},
+        "read_only": {"type": ["boolean", "string"]},
+        "restart": {"type": "string"},
+        "runtime": {
+          "type": "string"
+        },
+        "scale": {
+          "type": ["integer", "string"]
+        },
+        "security_opt": {"type": "array", "items": {"type": "string"}, "uniqueItems": true},
+        "shm_size": {"type": ["number", "string"]},
+        "secrets": {"$ref": "#/definitions/service_config_or_secret"},
+        "sysctls": {"$ref": "#/definitions/list_or_dict"},
+        "stdin_open": {"type": ["boolean", "string"]},
+        "stop_grace_period": {"type": "string"},
+        "stop_signal": {"type": "string"},
+        "storage_opt": {"type": "object"},
+        "tmpfs": {"$ref": "#/definitions/string_or_list"},
+        "tty": {"type": ["boolean", "string"]},
+        "ulimits": {"$ref": "#/definitions/ulimits"},
+        "user": {"type": "string"},
+        "uts": {"type": "string"},
+        "userns_mode": {"type": "string"},
+        "volumes": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "required": ["type"],
+                "properties": {
+                  "type": {"type": "string",
+                    "enum": ["bind", "volume", "tmpfs", "cluster", "npipe", "image"]
+                  },
+                  "source": {"type": "string"},
+                  "target": {"type": "string"},
+                  "read_only": {"type": ["boolean", "string"]},
+                  "consistency": {"type": "string"},
+                  "bind": {
+                    "type": "object",
+                    "properties": {
+                      "propagation": {"type": "string"},
+                      "create_host_path": {"type": ["boolean", "string"]},
+                      "recursive": {"type": "string", "enum": ["enabled", "disabled", "writable", "readonly"]},
+                      "selinux": {"type": "string", "enum": ["z", "Z"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "volume": {
+                    "type": "object",
+                    "properties": {
+                      "labels": {"$ref": "#/definitions/list_or_dict"},
+                      "nocopy": {"type": ["boolean", "string"]},
+                      "subpath": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "tmpfs": {
+                    "type": "object",
+                    "properties": {
+                      "size": {
+                        "oneOf": [
+                          {"type": "integer", "minimum": 0},
+                          {"type": "string"}
+                        ]
+                      },
+                      "mode": {"type": ["number", "string"]}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  },
+                  "image": {
+                    "type": "object",
+                    "properties": {
+                      "subpath": {"type": "string"}
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {"^x-": {}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            ]
+          },
+          "uniqueItems": true
+        },
+        "volumes_from": {
+          "type": "array",
+          "items": {"type": "string"},
+          "uniqueItems": true
+        },
+        "working_dir": {"type": "string"}
+      },
+      "patternProperties": {"^x-": {}},
+      "additionalProperties": false
+    },
+
+    "healthcheck": {
+      "type": "object",
+      "properties": {
+        "disable": {"type": ["boolean", "string"]},
+        "interval": {"type": "string"},
+        "retries": {"type": ["number", "string"]},
+        "test": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        },
+        "timeout": {"type": "string"},
+        "start_period": {"type": "string"},
+        "start_interval": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+    "development": {
+      "type": ["object", "null"],
+      "properties": {
+        "watch": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["path", "action"],
+            "properties": {
+              "ignore": {"$ref": "#/definitions/string_or_list"},
+              "include": {"$ref": "#/definitions/string_or_list"},
+              "path": {"type": "string"},
+              "action": {"type": "string", "enum": ["rebuild", "sync", "restart", "sync+restart", "sync+exec"]},
+              "target": {"type": "string"},
+              "exec": {"$ref": "#/definitions/service_hook"}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+    "deployment": {
+      "type": ["object", "null"],
+      "properties": {
+        "mode": {"type": "string"},
+        "endpoint_mode": {"type": "string"},
+        "replicas": {"type": ["integer", "string"]},
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "rollback_config": {
+          "type": "object",
+          "properties": {
+            "parallelism": {"type": ["integer", "string"]},
+            "delay": {"type": "string"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string"},
+            "max_failure_ratio": {"type": ["number", "string"]},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "update_config": {
+          "type": "object",
+          "properties": {
+            "parallelism": {"type": ["integer", "string"]},
+            "delay": {"type": "string"},
+            "failure_action": {"type": "string"},
+            "monitor": {"type": "string"},
+            "max_failure_ratio": {"type": ["number", "string"]},
+            "order": {"type": "string", "enum": [
+              "start-first", "stop-first"
+            ]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "resources": {
+          "type": "object",
+          "properties": {
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": ["number", "string"]},
+                "memory": {"type": "string"},
+                "pids": {"type": ["integer", "string"]}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            },
+            "reservations": {
+              "type": "object",
+              "properties": {
+                "cpus": {"type": ["number", "string"]},
+                "memory": {"type": "string"},
+                "generic_resources": {"$ref": "#/definitions/generic_resources"},
+                "devices": {"$ref": "#/definitions/devices"}
+              },
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "restart_policy": {
+          "type": "object",
+          "properties": {
+            "condition": {"type": "string"},
+            "delay": {"type": "string"},
+            "max_attempts": {"type": ["integer", "string"]},
+            "window": {"type": "string"}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "placement": {
+          "type": "object",
+          "properties": {
+            "constraints": {"type": "array", "items": {"type": "string"}},
+            "preferences": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "spread": {"type": "string"}
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            },
+            "max_replicas_per_node": {"type": ["integer", "string"]}
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "generic_resources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "discrete_resource_spec": {
+            "type": "object",
+            "properties": {
+              "kind": {"type": "string"},
+              "value": {"type": ["number", "string"]}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}}
+      }
+    },
+
+    "devices": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "capabilities": {"$ref": "#/definitions/list_of_strings"},
+          "count": {"type": ["string", "integer"]},
+          "device_ids": {"$ref": "#/definitions/list_of_strings"},
+          "driver":{"type": "string"},
+          "options":{"$ref": "#/definitions/list_or_dict"}
+        },
+        "additionalProperties": false,
+        "patternProperties": {"^x-": {}},
+        "required": [
+          "capabilities"
+        ]
+      }
+    },
+
+    "gpus": {
+      "oneOf": [
+        {"type": "string", "enum": ["all"]},
+        {"type": "array",
+         "items": {
+          "type": "object",
+            "properties": {
+              "capabilities": {"$ref": "#/definitions/list_of_strings"},
+              "count": {"type": ["string", "integer"]},
+              "device_ids": {"$ref": "#/definitions/list_of_strings"},
+              "driver":{"type": "string"},
+              "options":{"$ref": "#/definitions/list_or_dict"}
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        }
+      ]
+    },
+
+    "include": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "object",
+          "properties": {
+            "path": {"$ref": "#/definitions/string_or_list"},
+            "env_file": {"$ref": "#/definitions/string_or_list"},
+            "project_directory": {"type": "string"}
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+
+    "network": {
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "ipam": {
+          "type": "object",
+          "properties": {
+            "driver": {"type": "string"},
+            "config": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "subnet": {"type": "string"},
+                  "ip_range": {"type": "string"},
+                  "gateway": {"type": "string"},
+                  "aux_addresses": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {"^.+$": {"type": "string"}}
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {"^x-": {}}
+              }
+            },
+            "options": {
+              "type": "object",
+              "additionalProperties": false,
+              "patternProperties": {"^.+$": {"type": "string"}}
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "internal": {"type": ["boolean", "string"]},
+        "enable_ipv4": {"type": ["boolean", "string"]},
+        "enable_ipv6": {"type": ["boolean", "string"]},
+        "attachable": {"type": ["boolean", "string"]},
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "volume": {
+      "type": ["object", "null"],
+      "properties": {
+        "name": {"type": "string"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {"^x-": {}}
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "secret": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "environment": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {"type": "string"}
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "driver": {"type": "string"},
+        "driver_opts": {
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {"type": ["string", "number"]}
+          }
+        },
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "config": {
+      "type": "object",
+      "properties": {
+        "name": {"type": "string"},
+        "content": {"type": "string"},
+        "environment": {"type": "string"},
+        "file": {"type": "string"},
+        "external": {
+          "type": ["boolean", "string", "object"],
+          "properties": {
+            "name": {
+              "deprecated": true,
+              "type": "string"
+            }
+          }
+        },
+        "labels": {"$ref": "#/definitions/list_or_dict"},
+        "template_driver": {"type": "string"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}}
+    },
+
+    "command": {
+      "oneOf": [
+        {"type": "null"},
+        {"type": "string"},
+        {"type": "array","items": {"type": "string"}}
+      ]
+    },
+
+    "service_hook": {
+      "type": "object",
+      "properties": {
+        "command": {"$ref": "#/definitions/command"},
+        "user": {"type": "string"},
+        "privileged": {"type": ["boolean", "string"]},
+        "working_dir": {"type": "string"},
+        "environment": {"$ref": "#/definitions/list_or_dict"}
+      },
+      "additionalProperties": false,
+      "patternProperties": {"^x-": {}},
+      "required": ["command"]
+    },
+
+    "env_file": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {"type": "string"},
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "string"
+                  },
+                  "format": {
+                    "type": "string"
+                  },
+                  "required": {
+                    "type": ["boolean", "string"],
+                    "default": true
+                  }
+                },
+                "required": [
+                  "path"
+                ]
+              }
+            ]
+          }
+        }
+      ]
+    },
+
+    "label_file": {
+      "oneOf": [
+        {"type": "string"},
+        {
+          "type": "array",
+          "items": {"type": "string"}
+        }
+      ]
+    },
+
+    "string_or_list": {
+      "oneOf": [
+        {"type": "string"},
+        {"$ref": "#/definitions/list_of_strings"}
+      ]
+    },
+
+    "list_of_strings": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true
+    },
+
+    "list_or_dict": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "type": ["string", "number", "boolean", "null"]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "extra_hosts": {
+      "oneOf": [
+        {
+          "type": "object",
+          "patternProperties": {
+            ".+": {
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "uniqueItems": false
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        },
+        {"type": "array", "items": {"type": "string"}, "uniqueItems": true}
+      ]
+    },
+
+    "blkio_limit": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "rate": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "blkio_weight": {
+      "type": "object",
+      "properties": {
+        "path": {"type": "string"},
+        "weight": {"type": ["integer", "string"]}
+      },
+      "additionalProperties": false
+    },
+    "service_config_or_secret": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"type": "string"},
+          {
+            "type": "object",
+            "properties": {
+              "source": {"type": "string"},
+              "target": {"type": "string"},
+              "uid": {"type": "string"},
+              "gid": {"type": "string"},
+              "mode": {"type": ["number", "string"]}
+            },
+            "additionalProperties": false,
+            "patternProperties": {"^x-": {}}
+          }
+        ]
+      }
+    },
+    "ulimits": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z]+$": {
+          "oneOf": [
+            {"type": ["integer", "string"]},
+            {
+              "type": "object",
+              "properties": {
+                "hard": {"type": ["integer", "string"]},
+                "soft": {"type": ["integer", "string"]}
+              },
+              "required": ["soft", "hard"],
+              "additionalProperties": false,
+              "patternProperties": {"^x-": {}}
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/internal/compose/schema.go
+++ b/internal/compose/schema.go
@@ -1,0 +1,125 @@
+package compose
+
+import (
+	"bytes"
+	_ "embed"
+	"slices"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+//go:embed compose-spec.json
+var schemaData []byte
+
+var composeSchema *jsonschema.Schema
+
+func init() {
+	schema, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaData))
+	if err != nil {
+		return
+	}
+
+	compiler := jsonschema.NewCompiler()
+	if err := compiler.AddResource("schema.json", schema); err != nil {
+		return
+	}
+	compiled, err := compiler.Compile("schema.json")
+	if err != nil {
+		return
+	}
+	composeSchema = compiled
+}
+
+func schemaProperties() map[string]*jsonschema.Schema {
+	return composeSchema.Properties
+}
+
+func nodeProperties(nodes []*yaml.Node, line, column int) map[string]*jsonschema.Schema {
+	if composeSchema != nil && slices.Contains(composeSchema.Types.ToStrings(), "object") && composeSchema.Properties != nil {
+		if prop, ok := composeSchema.Properties[nodes[0].Value]; ok {
+			for regexp, property := range prop.PatternProperties {
+				if regexp.MatchString(nodes[1].Value) {
+					if property.Ref != nil {
+						return recurseNodeProperties(nodes, line, column, 2, property.Ref.Properties)
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func recurseNodeProperties(nodes []*yaml.Node, line, column, nodeOffset int, properties map[string]*jsonschema.Schema) map[string]*jsonschema.Schema {
+	if len(nodes) == nodeOffset || (len(nodes) >= nodeOffset+2 && nodes[nodeOffset].Column <= column && column < nodes[nodeOffset+1].Column) {
+		return properties
+	} else if column == nodes[nodeOffset].Column {
+		return properties
+	}
+
+	value := nodes[nodeOffset].Value
+	if prop, ok := properties[value]; ok {
+		if prop.Ref != nil {
+			if len(prop.Ref.Properties) > 0 {
+				return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Ref.Properties)
+			}
+			for regexp, property := range prop.Ref.PatternProperties {
+				if regexp.MatchString(nodes[nodeOffset+1].Value) {
+					for _, nested := range property.OneOf {
+						if slices.Contains(nested.Types.ToStrings(), "object") {
+							return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties)
+						}
+					}
+				}
+			}
+		}
+
+		for _, schema := range prop.OneOf {
+			if schema.Types != nil && slices.Contains(schema.Types.ToStrings(), "object") {
+				if len(schema.Properties) > 0 {
+					return recurseNodeProperties(nodes, line, column, nodeOffset+1, schema.Properties)
+				}
+
+				for regexp, property := range schema.PatternProperties {
+					if len(nodes) == nodeOffset+1 {
+						return nil
+					}
+
+					if regexp.MatchString(nodes[nodeOffset+1].Value) {
+						for _, nested := range property.OneOf {
+							if slices.Contains(nested.Types.ToStrings(), "object") {
+								return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties)
+							}
+						}
+					}
+				}
+			}
+		}
+
+		if schema, ok := prop.Items.(*jsonschema.Schema); ok {
+			for _, nested := range schema.OneOf {
+				if nested.Types != nil && slices.Contains(nested.Types.ToStrings(), "object") {
+					if len(nested.Properties) > 0 {
+						return recurseNodeProperties(nodes, line, column, nodeOffset+1, nested.Properties)
+					}
+				}
+			}
+		}
+
+		if nodes[nodeOffset].Column < column {
+			if nodes[nodeOffset].Line == line {
+				if prop.Enum == nil {
+					return nil
+				}
+				enumValues := make(map[string]*jsonschema.Schema)
+				for _, value := range prop.Enum.Values {
+					enumValues[value.(string)] = nil
+				}
+				return enumValues
+			}
+			return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Properties)
+		}
+		return prop.Properties
+	}
+	return nil
+}

--- a/internal/pkg/server/completion.go
+++ b/internal/pkg/server/completion.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/compose"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -17,6 +18,8 @@ func (s *Server) TextDocumentCompletion(ctx *glsp.Context, params *protocol.Comp
 
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Completion(ctx.Context, params, s.docs, doc.(document.BakeHCLDocument))
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+		return compose.Completion(ctx.Context, params, doc.(document.ComposeDocument))
 	}
 	return nil, nil
 }


### PR DESCRIPTION
The Compose specification is quite exhaustive so offering code completion based on schema introspection will help our users write them with heightened accuracy. This is just an initial pass with raw strings and does not support snippets or look into the schema with great detail. We should at least be suggesting the correct attribute names and enum values for the most basic cases though.