### PR TITLE
Run the builds on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
       - v*
     paths-ignore:
       - '**/*.md'
+  pull_request:
+    branches:
+      - '**'
 
 jobs:
   lint:


### PR DESCRIPTION
Pull requests are not triggering the builds which is not what we want. We want builds to run on every pull request.