### PR TITLE
Create a setting to disable Compose completions

### DIFF
--- a/internal/pkg/server/completion.go
+++ b/internal/pkg/server/completion.go
@@ -18,7 +18,7 @@ func (s *Server) TextDocumentCompletion(ctx *glsp.Context, params *protocol.Comp
 
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Completion(ctx.Context, params, s.docs, doc.(document.BakeHCLDocument))
-	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeCompletion {
 		return compose.Completion(ctx.Context, params, doc.(document.ComposeDocument))
 	}
 	return nil, nil

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -33,6 +33,12 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 			}
 		}
 
+		if settings, ok := clientConfig["dockercomposeExperimental"].(map[string]any); ok {
+			if composeCompletion, ok := settings["composeCompletion"].(bool); ok {
+				s.composeCompletion = composeCompletion
+			}
+		}
+
 		if value, ok := clientConfig["telemetry"].(string); ok {
 			s.updateTelemetrySetting(value)
 		}

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -64,6 +64,8 @@ type Server struct {
 	// within that Git folder.
 	analyzedFiles map[string]map[string]bool
 
+	composeCompletion bool
+
 	mutex sync.RWMutex
 }
 
@@ -83,6 +85,7 @@ func NewServer(docManager *document.Manager) *Server {
 		telemetry:                  telemetry.NewClient(),
 		scoutService:               scoutService,
 		sessionTelemetryProperties: sessionTelemetryProperties,
+		composeCompletion:          true,
 		diagnosticsCollectors: []textdocument.DiagnosticsCollector{
 			buildkit.NewBuildKitDiagnosticsCollector(),
 			scoutService,


### PR DESCRIPTION
There are other language servers that provide Compose completions. By introducing an experimental setting to disable Compose completions, we can provide users with the ability to filter out our completions if desired. We will come back to this decision in the future as the Compose completions feature continues to be developed and refined.