### PR TITLE
Return hover results for Compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Compose
+  - textDocument/hover
+    - return the hover results for Compose files
+
 ## [0.4.1] - 2025-04-29
 
 ### Fixed
@@ -174,7 +182,8 @@ All notable changes to the Docker Language Server will be documented in this fil
   - textDocument/semanticTokens/full
     - provide syntax highlighting for Bake files
 
-[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.4.0...main
+[Unreleased]: https://github.com/docker/docker-language-server/compare/v0.4.1...main
+[0.4.1]: https://github.com/docker/docker-language-server/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/docker/docker-language-server/compare/v0.3.8...v0.4.0
 [0.3.8]: https://github.com/docker/docker-language-server/compare/v0.3.7...v0.3.8
 [0.3.7]: https://github.com/docker/docker-language-server/compare/v0.3.6...v0.3.7

--- a/e2e-tests/hover_test.go
+++ b/e2e-tests/hover_test.go
@@ -61,7 +61,7 @@ func TestHover(t *testing.T) {
 		name                string
 		content             string
 		position            protocol.Position
-		value               string
+		result              *protocol.Hover
 	}{
 		{
 			languageID:          protocol.DockerBakeLanguage,
@@ -69,7 +69,12 @@ func TestHover(t *testing.T) {
 			name:                "hover over target block type",
 			content:             "target \"api\" {}",
 			position:            protocol.Position{Line: 0, Character: 3},
-			value:               "**target** _Block_\n\nA target reflects a single `docker build` invocation.",
+			result: &protocol.Hover{
+				Contents: protocol.MarkupContent{
+					Kind:  protocol.MarkupKindMarkdown,
+					Value: "**target** _Block_\n\nA target reflects a single `docker build` invocation.",
+				},
+			},
 		},
 		{
 			languageID:          protocol.DockerfileLanguage,
@@ -77,7 +82,25 @@ func TestHover(t *testing.T) {
 			name:                "hover over alpine:3.16.1",
 			content:             "FROM alpine:3.16.1",
 			position:            protocol.Position{Line: 0, Character: 8},
-			value:               "Current image vulnerabilities:   1C   3H   9M   0L \r\n\r\nRecommended tags:\n\n<table>\n<tr><td><code>3.21.3</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.20.6</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.18.12</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n</table>\n",
+			result: &protocol.Hover{
+				Contents: protocol.MarkupContent{
+					Kind:  protocol.MarkupKindMarkdown,
+					Value: "Current image vulnerabilities:   1C   3H   9M   0L \r\n\r\nRecommended tags:\n\n<table>\n<tr><td><code>3.21.3</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.20.6</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.18.12</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n</table>\n",
+				},
+			},
+		},
+		{
+			languageID:          protocol.DockerComposeLanguage,
+			fileExtensionSuffix: ".yaml",
+			name:                "version description",
+			content:             "version: 1.2.3",
+			position:            protocol.Position{Line: 0, Character: 4},
+			result: &protocol.Hover{
+				Contents: protocol.MarkupContent{
+					Kind:  protocol.MarkupKindPlainText,
+					Value: "declared for backward compatibility, ignored.",
+				},
+			},
 		},
 	}
 
@@ -95,11 +118,7 @@ func TestHover(t *testing.T) {
 				},
 			}, &hover)
 			require.NoError(t, err)
-			require.Nil(t, hover.Range)
-			markupContent, ok := hover.Contents.(protocol.MarkupContent)
-			require.True(t, ok)
-			require.Equal(t, protocol.MarkupKindMarkdown, markupContent.Kind)
-			require.Equal(t, tc.value, markupContent.Value)
+			require.Equal(t, tc.result, hover)
 		})
 	}
 

--- a/internal/pkg/server/hover.go
+++ b/internal/pkg/server/hover.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/compose"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -21,7 +22,7 @@ func (s *Server) TextDocumentHover(ctx *glsp.Context, params *protocol.HoverPara
 	if language == protocol.DockerBakeLanguage {
 		return hcl.Hover(ctx.Context, params, doc.(document.BakeHCLDocument))
 	} else if language == protocol.DockerComposeLanguage {
-		return nil, nil
+		return compose.Hover(ctx.Context, params, doc.(document.ComposeDocument))
 	}
 
 	dockerfileDocument, ok := doc.(document.DockerfileDocument)


### PR DESCRIPTION
Unfortunately, we added the code for calculating the hover results but did not change the `textDocument/hover` handler to actually call the function.