### PR TITLE
Begin refactoring go-yaml/yaml to goccy/go-yaml

### DIFF
--- a/internal/compose/definition_test.go
+++ b/internal/compose/definition_test.go
@@ -157,37 +157,41 @@ services:
 services:
   test:
     image: alpine:3.21
+    depends_on:
+      - redis
     configs:
-    - def
+      - def
+  redis:
+    image: redis
 
 configs:
   def:
     file: ./httpd.conf`,
-			line:      5,
-			character: 8,
+			line:      7,
+			character: 10,
 			locations: []protocol.Location{
 				{
 					URI: composeFileURI,
 					Range: protocol.Range{
-						Start: protocol.Position{Line: 8, Character: 2},
-						End:   protocol.Position{Line: 8, Character: 5},
+						Start: protocol.Position{Line: 12, Character: 2},
+						End:   protocol.Position{Line: 12, Character: 5},
 					},
 				},
 			},
 			links: []protocol.LocationLink{
 				{
 					OriginSelectionRange: &protocol.Range{
-						Start: protocol.Position{Line: 5, Character: 6},
-						End:   protocol.Position{Line: 5, Character: 9},
+						Start: protocol.Position{Line: 7, Character: 8},
+						End:   protocol.Position{Line: 7, Character: 11},
 					},
 					TargetURI: composeFileURI,
 					TargetRange: protocol.Range{
-						Start: protocol.Position{Line: 8, Character: 2},
-						End:   protocol.Position{Line: 8, Character: 5},
+						Start: protocol.Position{Line: 12, Character: 2},
+						End:   protocol.Position{Line: 12, Character: 5},
 					},
 					TargetSelectionRange: protocol.Range{
-						Start: protocol.Position{Line: 8, Character: 2},
-						End:   protocol.Position{Line: 8, Character: 5},
+						Start: protocol.Position{Line: 12, Character: 2},
+						End:   protocol.Position{Line: 12, Character: 5},
 					},
 				},
 			},

--- a/internal/compose/documentLink.go
+++ b/internal/compose/documentLink.go
@@ -10,8 +10,103 @@ import (
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/token"
 )
+
+func createIncludeLink(u *url.URL, node *token.Token) *protocol.DocumentLink {
+	abs, err := types.AbsolutePath(u, node.Value)
+	if err != nil {
+		return nil
+	}
+	offset := 0
+	if node.Type == token.DoubleQuoteType {
+		offset = 1
+	}
+	return &protocol.DocumentLink{
+		Range: protocol.Range{
+			Start: protocol.Position{
+				Line:      protocol.UInteger(node.Position.Line - 1),
+				Character: protocol.UInteger(node.Position.Column + offset - 1),
+			},
+			End: protocol.Position{
+				Line:      protocol.UInteger(node.Position.Line - 1),
+				Character: protocol.UInteger(node.Position.Column + offset + len(node.Value) - 1),
+			},
+		},
+		Target:  types.CreateStringPointer(protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(abs), "/")))),
+		Tooltip: types.CreateStringPointer(abs),
+	}
+}
+
+func createImageLinks(serviceNode *ast.MappingValueNode) *protocol.DocumentLink {
+	if service, ok := serviceNode.Value.(*ast.MappingValueNode); ok {
+		if service.Key.GetToken().Value == "image" {
+			value := service.Value.GetToken().Value
+			linkedText, link := extractImageLink(value)
+			return &protocol.DocumentLink{
+				Range: protocol.Range{
+					Start: protocol.Position{
+						Line:      protocol.UInteger(service.Value.GetToken().Position.Line) - 1,
+						Character: protocol.UInteger(service.Value.GetToken().Position.Column) - 1,
+					},
+					End: protocol.Position{
+						Line:      protocol.UInteger(service.Value.GetToken().Position.Line) - 1,
+						Character: protocol.UInteger(service.Value.GetToken().Position.Column - 1 + len(linkedText)),
+					},
+				},
+				Target:  types.CreateStringPointer(link),
+				Tooltip: types.CreateStringPointer(link),
+			}
+		}
+	}
+	return nil
+}
+
+func scanForLinks(u *url.URL, n *ast.MappingValueNode) []protocol.DocumentLink {
+	if s, ok := n.Key.(*ast.StringNode); ok {
+		links := []protocol.DocumentLink{}
+		switch s.Value {
+		case "include":
+			if sequence, ok := n.Value.(*ast.SequenceNode); ok {
+				for _, entry := range sequence.Values {
+					if mappingNode, ok := entry.(*ast.MappingValueNode); ok {
+						entry = mappingNode.Value
+					}
+					if sequenceNode, ok := entry.(*ast.SequenceNode); ok {
+						for _, entry := range sequenceNode.Values {
+							link := createIncludeLink(u, entry.GetToken())
+							if link != nil {
+								links = append(links, *link)
+							}
+						}
+					} else {
+						link := createIncludeLink(u, entry.GetToken())
+						if link != nil {
+							links = append(links, *link)
+						}
+					}
+				}
+			}
+		case "services":
+			if mappingNode, ok := n.Value.(*ast.MappingNode); ok {
+				for _, node := range mappingNode.Values {
+					link := createImageLinks(node)
+					if link != nil {
+						links = append(links, *link)
+					}
+				}
+			} else if serviceNode, ok := n.Value.(*ast.MappingValueNode); ok {
+				link := createImageLinks(serviceNode)
+				if link != nil {
+					links = append(links, *link)
+				}
+			}
+		}
+		return links
+	}
+	return nil
+}
 
 func DocumentLink(ctx context.Context, documentURI protocol.URI, doc document.ComposeDocument) ([]protocol.DocumentLink, error) {
 	url, err := url.Parse(string(documentURI))
@@ -19,54 +114,19 @@ func DocumentLink(ctx context.Context, documentURI protocol.URI, doc document.Co
 		return nil, fmt.Errorf("LSP client sent invalid URI: %v", string(documentURI))
 	}
 
-	links := []protocol.DocumentLink{}
-	results, _ := DocumentSymbol(ctx, doc)
-	for _, result := range results {
-		if symbol, ok := result.(*protocol.DocumentSymbol); ok && symbol.Kind == protocol.SymbolKindModule {
-			abs, err := types.AbsolutePath(url, symbol.Name)
-			if err == nil {
-				links = append(links, protocol.DocumentLink{
-					Range:   symbol.Range,
-					Target:  types.CreateStringPointer(protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(abs), "/")))),
-					Tooltip: types.CreateStringPointer(abs),
-				})
-			}
-		}
+	file := doc.File()
+	if file == nil || len(file.Docs) == 0 {
+		return nil, nil
 	}
 
-	root := doc.RootNode()
-	if len(root.Content) > 0 {
-		for i := range root.Content[0].Content {
-			switch root.Content[0].Content[i].Value {
-			case "services":
-				if root.Content[0].Content[i+1].Kind != yaml.MappingNode {
-					continue
-				}
-
-				for j := 0; j < len(root.Content[0].Content[i+1].Content); j += 2 {
-					serviceProperties := root.Content[0].Content[i+1].Content[j+1].Content
-					for k := 0; k < len(serviceProperties); k += 2 {
-						if serviceProperties[k].Value == "image" {
-							imageNode := serviceProperties[k+1]
-							linkedText, link := extractImageLink(imageNode.Value)
-							links = append(links, protocol.DocumentLink{
-								Range: protocol.Range{
-									Start: protocol.Position{
-										Line:      protocol.UInteger(imageNode.Line) - 1,
-										Character: protocol.UInteger(imageNode.Column) - 1,
-									},
-									End: protocol.Position{
-										Line:      protocol.UInteger(imageNode.Line) - 1,
-										Character: protocol.UInteger(imageNode.Column - 1 + len(linkedText)),
-									},
-								},
-								Target:  types.CreateStringPointer(link),
-								Tooltip: types.CreateStringPointer(link),
-							})
-						}
-					}
-				}
+	links := []protocol.DocumentLink{}
+	for _, documentNode := range file.Docs {
+		if mappingNode, ok := documentNode.Body.(*ast.MappingNode); ok {
+			for _, node := range mappingNode.Values {
+				links = append(links, scanForLinks(url, node)...)
 			}
+		} else if mappingNodeValue, ok := documentNode.Body.(*ast.MappingValueNode); ok {
+			links = append(links, scanForLinks(url, mappingNodeValue)...)
 		}
 	}
 	return links, nil

--- a/internal/compose/documentLink_test.go
+++ b/internal/compose/documentLink_test.go
@@ -14,12 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func documentLinkTooltip(testsFolder, fileName string) *string {
+	tooltip := filepath.Join(testsFolder, fileName)
+	return &tooltip
+}
+
+func documentLinkTarget(testsFolder, fileName string) *string {
+	path := filepath.Join(testsFolder, fileName)
+	target := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(path), "/"))
+	return &target
+}
+
 func TestDocumentLink_IncludedFiles(t *testing.T) {
 	testsFolder := filepath.Join(os.TempDir(), "composeDocumentLinkTests")
 	composeFilePath := filepath.Join(testsFolder, "docker-compose.yml")
-	referencedFilePath := filepath.Join(testsFolder, "file.yml")
 	composeStringURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(composeFilePath), "/"))
-	referencedFileStringURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(referencedFilePath), "/"))
 
 	testCases := []struct {
 		name    string
@@ -27,17 +36,123 @@ func TestDocumentLink_IncludedFiles(t *testing.T) {
 		links   []protocol.DocumentLink
 	}{
 		{
-			name: "included files, short syntax",
+			name:    "empty file",
+			content: "",
+			links:   nil,
+		},
+		{
+			name: "included files, string array",
 			content: `include:
-  - file.yml`,
+  - file.yml
+  - "file2.yml"`,
 			links: []protocol.DocumentLink{
 				{
 					Range: protocol.Range{
 						Start: protocol.Position{Line: 1, Character: 4},
 						End:   protocol.Position{Line: 1, Character: 12},
 					},
-					Target:  types.CreateStringPointer(referencedFileStringURI),
-					Tooltip: types.CreateStringPointer(referencedFilePath),
+					Target:  documentLinkTarget(testsFolder, "file.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file.yml"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 5},
+						End:   protocol.Position{Line: 2, Character: 14},
+					},
+					Target:  documentLinkTarget(testsFolder, "file2.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file2.yml"),
+				},
+			},
+		},
+		{
+			name: "included files, path as a string",
+			content: `include:
+  - path: file.yml
+  - path: "file2.yml"`,
+			links: []protocol.DocumentLink{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 10},
+						End:   protocol.Position{Line: 1, Character: 18},
+					},
+					Target:  documentLinkTarget(testsFolder, "file.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file.yml"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 11},
+						End:   protocol.Position{Line: 2, Character: 20},
+					},
+					Target:  documentLinkTarget(testsFolder, "file2.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file2.yml"),
+				},
+			},
+		},
+		{
+			name: "included files, mixed paths",
+			content: `
+include:
+  - file.yml
+  - path: file2.yml
+  - path:
+    - file3.yml`,
+			links: []protocol.DocumentLink{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 4},
+						End:   protocol.Position{Line: 2, Character: 12},
+					},
+					Target:  documentLinkTarget(testsFolder, "file.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file.yml"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 10},
+						End:   protocol.Position{Line: 3, Character: 19},
+					},
+					Target:  documentLinkTarget(testsFolder, "file2.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file2.yml"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 6},
+						End:   protocol.Position{Line: 5, Character: 15},
+					},
+					Target:  documentLinkTarget(testsFolder, "file3.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file3.yml"),
+				},
+			},
+		},
+		{
+			name:    "include declared with no content",
+			content: "include:",
+			links:   []protocol.DocumentLink{},
+		},
+		{
+			name: "regular file",
+			content: `
+services:
+  backend:
+
+include:
+  - file.yml
+  - "file2.yml"`,
+			links: []protocol.DocumentLink{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 4},
+						End:   protocol.Position{Line: 5, Character: 12},
+					},
+					Target:  documentLinkTarget(testsFolder, "file.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file.yml"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 5},
+						End:   protocol.Position{Line: 6, Character: 14},
+					},
+					Target:  documentLinkTarget(testsFolder, "file2.yml"),
+					Tooltip: documentLinkTooltip(testsFolder, "file2.yml"),
 				},
 			},
 		},
@@ -73,6 +188,33 @@ services:
 					},
 					Target:  types.CreateStringPointer("https://hub.docker.com/_/alpine"),
 					Tooltip: types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+				},
+			},
+		},
+		{
+			name: "two services",
+			content: `
+services:
+  test:
+    image: alpine
+  test2:
+    image: postgres`,
+			links: []protocol.DocumentLink{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 11},
+						End:   protocol.Position{Line: 3, Character: 17},
+					},
+					Target:  types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+					Tooltip: types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 11},
+						End:   protocol.Position{Line: 5, Character: 19},
+					},
+					Target:  types.CreateStringPointer("https://hub.docker.com/_/postgres"),
+					Tooltip: types.CreateStringPointer("https://hub.docker.com/_/postgres"),
 				},
 			},
 		},
@@ -234,7 +376,37 @@ services:
 			content: `
 services:
   - `,
-			links: []protocol.DocumentLink{},
+			links: nil,
+		},
+		{
+			name: "image: alpine",
+			content: `
+---
+services:
+  backend:
+    image: alpine:3.20
+---
+services:
+  backend2:
+    image: alpine:3.21`,
+			links: []protocol.DocumentLink{
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 11},
+						End:   protocol.Position{Line: 4, Character: 17},
+					},
+					Target:  types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+					Tooltip: types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+				},
+				{
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 8, Character: 11},
+						End:   protocol.Position{Line: 8, Character: 17},
+					},
+					Target:  types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+					Tooltip: types.CreateStringPointer("https://hub.docker.com/_/alpine"),
+				},
+			},
 		},
 	}
 

--- a/internal/pkg/document/dockerComposeDocument.go
+++ b/internal/pkg/document/dockerComposeDocument.go
@@ -4,6 +4,8 @@ import (
 	"sync"
 
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
 	"go.lsp.dev/uri"
 	"gopkg.in/yaml.v3"
 )
@@ -11,12 +13,14 @@ import (
 type ComposeDocument interface {
 	Document
 	RootNode() yaml.Node
+	File() *ast.File
 }
 
 type composeDocument struct {
 	document
 	mutex    sync.Mutex
 	rootNode yaml.Node
+	file     *ast.File
 }
 
 func NewComposeDocument(u uri.URI, version int32, input []byte) ComposeDocument {
@@ -39,6 +43,7 @@ func (d *composeDocument) parse(_ bool) bool {
 	defer d.mutex.Unlock()
 
 	_ = yaml.Unmarshal([]byte(d.input), &d.rootNode)
+	d.file, _ = parser.ParseBytes(d.input, 0)
 	return true
 }
 
@@ -48,4 +53,8 @@ func (d *composeDocument) copy() Document {
 
 func (d *composeDocument) RootNode() yaml.Node {
 	return d.rootNode
+}
+
+func (d *composeDocument) File() *ast.File {
+	return d.file
 }


### PR DESCRIPTION
As `go-yaml/yaml` has been archived, we should slowly replace our usages to `goccy/go-yaml` where possible.