### PR TITLE
Preserve instruction flags for `not_pinned_digest` code actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- Dockerfile
+  - textDocument/codeAction
+    - preserve instruction flags when fixing a `not_pinned_digest` diagnostic ([#123](https://github.com/docker/docker-language-server/issues/123))
 - Compose
   - textDocument/completion
     - resolved a spacing offset issue with object or array completions ([#115](https://github.com/docker/docker-language-server/issues/115))

--- a/internal/bake/hcl/diagnosticsCollector.go
+++ b/internal/bake/hcl/diagnosticsCollector.go
@@ -152,7 +152,7 @@ func (c *BakeHCLDiagnosticsCollector) CollectDiagnostics(source, workspaceFolder
 									for _, diagnostic := range imageDiagnostics {
 										if diagnostic.Kind == "critical_high_vulnerabilities" || diagnostic.Kind == "vulnerabilities" {
 											rng := templateExpr.SrcRange
-											diagnostics = append(diagnostics, scout.ConvertDiagnostic(diagnostic, nil, source, createProtocolRange(rng, true), nil))
+											diagnostics = append(diagnostics, scout.ConvertDiagnostic(diagnostic, source, createProtocolRange(rng, true), nil))
 											break
 										}
 									}

--- a/internal/scout/service_test.go
+++ b/internal/scout/service_test.go
@@ -34,6 +34,12 @@ func TestCalculateDiagnostics(t *testing.T) {
 						End:   protocol.Position{Line: 0, Character: 18},
 					},
 					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityHint),
+					Data: []types.NamedEdit{
+						{
+							Title: "Pin the base image digest",
+							Edit:  "FROM alpine:3.16.1@sha256:7580ece7963bfa863801466c0a488f11c86f85d9988051a9f9c68cb27f6b7872",
+						},
+					},
 				},
 				{
 					Message: "The image contains 1 critical and 3 high vulnerabilities",
@@ -55,6 +61,76 @@ func TestCalculateDiagnostics(t *testing.T) {
 						End:   protocol.Position{Line: 0, Character: 18},
 					},
 					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityInformation),
+					Data: []types.NamedEdit{
+						{
+							Title: "Update image to preferred tag (3.21.3)",
+							Edit:  "FROM alpine:3.21.3",
+						},
+						{
+							Title: "Update image OS minor version (3.20.6)",
+							Edit:  "FROM alpine:3.20.6",
+						},
+						{
+							Title: "Update image OS minor version (3.18.12)",
+							Edit:  "FROM alpine:3.18.12",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "outdated alpine:3.16.1 with --platform flag",
+			content: "FROM --platform=$BUILDPLATFORM alpine:3.16.1",
+			diagnostics: []protocol.Diagnostic{
+				{
+					Message: "The image can be pinned to a digest",
+					Source:  types.CreateStringPointer("scout-testing-source"),
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 44},
+					},
+					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityHint),
+					Data: []types.NamedEdit{
+						{
+							Title: "Pin the base image digest",
+							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.16.1@sha256:7580ece7963bfa863801466c0a488f11c86f85d9988051a9f9c68cb27f6b7872",
+						},
+					},
+				},
+				{
+					Message: "The image contains 1 critical and 3 high vulnerabilities",
+					Source:  types.CreateStringPointer("scout-testing-source"),
+					CodeDescription: &protocol.CodeDescription{
+						HRef: "https://hub.docker.com/layers/library/alpine/3.16.1/images/sha256-9b2a28eb47540823042a2ba401386845089bb7b62a9637d55816132c4c3c36eb",
+					},
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 44},
+					},
+					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityWarning),
+				},
+				{
+					Message: "Tag recommendations available",
+					Source:  types.CreateStringPointer("scout-testing-source"),
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 0, Character: 0},
+						End:   protocol.Position{Line: 0, Character: 44},
+					},
+					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityInformation),
+					Data: []types.NamedEdit{
+						{
+							Title: "Update image to preferred tag (3.21.3)",
+							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.21.3",
+						},
+						{
+							Title: "Update image OS minor version (3.20.6)",
+							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.20.6",
+						},
+						{
+							Title: "Update image OS minor version (3.18.12)",
+							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.18.12",
+						},
+					},
 				},
 			},
 		},
@@ -116,6 +192,7 @@ func TestCalculateDiagnostics(t *testing.T) {
 							require.Equal(t, expectedDiagnostic.Severity, diagnostic.Severity)
 							require.Equal(t, expectedDiagnostic.Source, diagnostic.Source)
 							require.Equal(t, expectedDiagnostic.CodeDescription, diagnostic.CodeDescription)
+							require.Equal(t, expectedDiagnostic.Data, diagnostic.Data)
 							found = true
 							break
 						}

--- a/internal/scout/types.go
+++ b/internal/scout/types.go
@@ -1,8 +1,6 @@
 package scout
 
 import (
-	"strings"
-
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
 )
@@ -63,7 +61,7 @@ func (k *ScoutImageKey) CacheKey() string {
 	return k.Image
 }
 
-func ConvertDiagnostic(diagnostic Diagnostic, words []string, source string, rng protocol.Range, edits []Edit) protocol.Diagnostic {
+func ConvertDiagnostic(diagnostic Diagnostic, source string, rng protocol.Range, edits []types.NamedEdit) protocol.Diagnostic {
 	lspDiagnostic := protocol.Diagnostic{}
 	lspDiagnostic.Code = &protocol.IntegerOrString{Value: diagnostic.Kind}
 	lspDiagnostic.Message = diagnostic.Message
@@ -86,20 +84,8 @@ func ConvertDiagnostic(diagnostic Diagnostic, words []string, source string, rng
 		lspDiagnostic.Severity = types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityHint)
 	}
 
-	includedEdits := []types.NamedEdit{}
-	for _, edit := range edits {
-		if lspDiagnostic.Code.Value == edit.Diagnostic {
-			words[1] = edit.Edit
-			edit.Edit = strings.Join(words, " ")
-			includedEdits = append(includedEdits, types.NamedEdit{
-				Title: edit.Title,
-				Edit:  edit.Edit,
-			})
-		}
-	}
-
-	if len(includedEdits) > 0 {
-		lspDiagnostic.Data = includedEdits
+	if len(edits) > 0 {
+		lspDiagnostic.Data = edits
 	}
 	return lspDiagnostic
 }


### PR DESCRIPTION
When executing a code action for pinning an image, we should make sure we rewrite the `FROM` instruction while preserving any flags that have been set.

Fixes #123.