### PR TITLE
Consider array schema and indentation before returning items

### DIFF
--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -26,6 +26,21 @@ func prefix(line string, character int) string {
 	return sb.String()
 }
 
+func array(line string, character int) bool {
+	isArray := false
+	for i := range character {
+		if unicode.IsSpace(rune(line[i])) {
+			continue
+		} else if line[i] == '-' {
+			isArray = true
+		} else {
+			isArray = false
+			break
+		}
+	}
+	return isArray
+}
+
 func Completion(ctx context.Context, params *protocol.CompletionParams, doc document.ComposeDocument) (*protocol.CompletionList, error) {
 	if params.Position.Character == 0 {
 		items := []protocol.CompletionItem{}
@@ -69,7 +84,11 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, doc docu
 	}
 
 	items := []protocol.CompletionItem{}
-	nodeProps := nodeProperties(path, line, character)
+	isArray := array(lines[lspLine], character-1)
+	nodeProps, arrayAttributes := nodeProperties(path, line, character)
+	if isArray != arrayAttributes {
+		return nil, nil
+	}
 	if schema, ok := nodeProps.(*jsonschema.Schema); ok {
 		if schema.Enum != nil {
 			for _, value := range schema.Enum.Values {

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -1832,6 +1832,29 @@ networks:
 			character: 2,
 			list:      nil,
 		},
+		{
+			name: "configs should not suggest attributes as-is",
+			content: `
+services:
+  test:
+    configs:
+      `,
+			line:      4,
+			character: 6,
+			list:      nil,
+		},
+		{
+			name: "array items should still consider indentation when calculating completion items",
+			content: `
+services:
+  test:
+    configs:
+      - mode: 0
+      `,
+			line:      5,
+			character: 6,
+			list:      nil,
+		},
 	}
 
 	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))
@@ -1846,11 +1869,7 @@ networks:
 				},
 			}, doc)
 			require.NoError(t, err)
-			if tc.list == nil {
-				require.Nil(t, list)
-			} else {
-				require.Equal(t, tc.list, list)
-			}
+			require.Equal(t, tc.list, list)
 		})
 	}
 }

--- a/internal/compose/schema.go
+++ b/internal/compose/schema.go
@@ -35,44 +35,44 @@ func schemaProperties() map[string]*jsonschema.Schema {
 	return composeSchema.Properties
 }
 
-func nodeProperties(nodes []*ast.MappingValueNode, line, column int) any {
+func nodeProperties(nodes []*ast.MappingValueNode, line, column int) (any, bool) {
 	if composeSchema != nil && slices.Contains(composeSchema.Types.ToStrings(), "object") && composeSchema.Properties != nil {
 		if prop, ok := composeSchema.Properties[nodes[0].Key.GetToken().Value]; ok {
 			for regexp, property := range prop.PatternProperties {
 				if regexp.MatchString(nodes[1].Key.GetToken().Value) {
 					if property.Ref != nil {
-						return recurseNodeProperties(nodes, line, column, 2, property.Ref.Properties)
+						return recurseNodeProperties(nodes, line, column, 2, property.Ref.Properties, false)
 					}
 				}
 			}
 		}
 	}
-	return nil
+	return nil, false
 }
 
-func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffset int, properties map[string]*jsonschema.Schema) any {
+func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffset int, properties map[string]*jsonschema.Schema, arrayAttributes bool) (any, bool) {
 	if len(nodes) == nodeOffset {
-		return properties
+		return properties, arrayAttributes
 	}
-	if len(nodes) >= nodeOffset+2 && nodes[nodeOffset].Key.GetToken().Position.Column <= column && column < nodes[nodeOffset+1].Key.GetToken().Position.Column {
-		return properties
+	if len(nodes) >= nodeOffset+2 && nodes[nodeOffset].Key.GetToken().Position.Column == column {
+		return properties, false
 	}
 	if column == nodes[nodeOffset].Key.GetToken().Position.Column {
-		return properties
+		return properties, false
 	}
 
 	value := nodes[nodeOffset].Key.GetToken().Value
 	if prop, ok := properties[value]; ok {
 		if prop.Ref != nil {
 			if len(prop.Ref.Properties) > 0 {
-				return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Ref.Properties)
+				return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Ref.Properties, false)
 			}
 			for regexp, property := range prop.Ref.PatternProperties {
 				nextValue := nodes[nodeOffset+1].Key.GetToken().Value
 				if regexp.MatchString(nextValue) {
 					for _, nested := range property.OneOf {
 						if slices.Contains(nested.Types.ToStrings(), "object") {
-							return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties)
+							return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties, false)
 						}
 					}
 				}
@@ -81,7 +81,7 @@ func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffs
 				for _, nested := range schema.OneOf {
 					if nested.Types != nil && slices.Contains(nested.Types.ToStrings(), "object") {
 						if len(nested.Properties) > 0 {
-							return recurseNodeProperties(nodes, line, column, nodeOffset+1, nested.Properties)
+							return recurseNodeProperties(nodes, line, column, nodeOffset+1, nested.Properties, true)
 						}
 					}
 				}
@@ -91,19 +91,19 @@ func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffs
 		for _, schema := range prop.OneOf {
 			if schema.Types != nil && slices.Contains(schema.Types.ToStrings(), "object") {
 				if len(schema.Properties) > 0 {
-					return recurseNodeProperties(nodes, line, column, nodeOffset+1, schema.Properties)
+					return recurseNodeProperties(nodes, line, column, nodeOffset+1, schema.Properties, false)
 				}
 
 				for regexp, property := range schema.PatternProperties {
 					if len(nodes) == nodeOffset+1 {
-						return nil
+						return nil, false
 					}
 
 					nextValue := nodes[nodeOffset+1].Key.GetToken().Value
 					if regexp.MatchString(nextValue) {
 						for _, nested := range property.OneOf {
 							if slices.Contains(nested.Types.ToStrings(), "object") {
-								return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties)
+								return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties, false)
 							}
 						}
 					}
@@ -115,7 +115,7 @@ func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffs
 			for _, nested := range schema.OneOf {
 				if nested.Types != nil && slices.Contains(nested.Types.ToStrings(), "object") {
 					if len(nested.Properties) > 0 {
-						return recurseNodeProperties(nodes, line, column, nodeOffset+1, nested.Properties)
+						return recurseNodeProperties(nodes, line, column, nodeOffset+1, nested.Properties, true)
 					}
 				}
 			}
@@ -123,11 +123,11 @@ func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffs
 
 		if nodes[nodeOffset].Key.GetToken().Position.Column < column {
 			if nodes[nodeOffset].Key.GetToken().Position.Line == line {
-				return prop
+				return prop, false
 			}
-			return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Properties)
+			return recurseNodeProperties(nodes, line, column, nodeOffset+1, prop.Properties, false)
 		}
-		return prop.Properties
+		return prop.Properties, false
 	}
-	return properties
+	return properties, false
 }


### PR DESCRIPTION
We need array items to actually have a hyphen in the front before suggesting items. We should also consider indentation more strictly instead of assuming anything in between the indentation levels is valid.