### PR TITLE
Add inlay hints support for non-object attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ All notable changes to the Docker Language Server will be documented in this fil
 ### Added
 
 - Compose
-  - improve code completion by automatically including required attributes in completion items ([#155](https://github.com/docker/docker-language-server/issues/155))
+  - textDocument/completion
+    - improve code completion by automatically including required attributes in completion items ([#155](https://github.com/docker/docker-language-server/issues/155))
+  - textDocument/inlayHint
+    - show the parent service's value if it is being overridden and they are not object attributes ([#156](https://github.com/docker/docker-language-server/issues/156))
 
 ### Fixed
 
@@ -104,7 +107,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Bake
   - textDocument/publishDiagnostics
     - consider the context attribute when determining which Dockerfile the Bake target is for ([#57](https://github.com/docker/docker-language-server/issues/57))
-  - textDocument/inlayHints
+  - textDocument/inlayHint
     - consider the context attribute when determining which Dockerfile to use for inlaying default values of `ARG` variables ([#60](https://github.com/docker/docker-language-server/pull/60))
   - textDocument/completion
     - consider the context attribute when determining which Dockerfile to use for looking up build stages ([#61](https://github.com/docker/docker-language-server/pull/61))

--- a/internal/compose/inlayHint.go
+++ b/internal/compose/inlayHint.go
@@ -1,0 +1,108 @@
+package compose
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/docker/docker-language-server/internal/types"
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/token"
+)
+
+func allServiceProperties(node ast.Node) map[string]map[string]ast.Node {
+	if servicesNode, ok := node.(*ast.MappingNode); ok {
+		services := map[string]map[string]ast.Node{}
+		for _, serviceNode := range servicesNode.Values {
+			if properties, ok := serviceNode.Value.(*ast.MappingNode); ok {
+				serviceProperties := map[string]ast.Node{}
+				for _, property := range properties.Values {
+					serviceProperties[property.Key.GetToken().Value] = property.Value
+				}
+				services[serviceNode.Key.GetToken().Value] = serviceProperties
+			}
+		}
+		return services
+	}
+	return nil
+}
+
+func hierarchyProperties(service string, serviceProps map[string]map[string]ast.Node, chain []map[string]ast.Node) []map[string]ast.Node {
+	if extends, ok := serviceProps[service]["extends"]; ok {
+		if s, ok := extends.(*ast.StringNode); ok {
+			chain = append(chain, hierarchyProperties(s.Value, serviceProps, chain)...)
+		} else if mappingNode, ok := extends.(*ast.MappingNode); ok {
+			external := false
+			for _, value := range mappingNode.Values {
+				if value.Key.GetToken().Value == "file" {
+					external = true
+					break
+				}
+			}
+
+			if !external {
+				for _, value := range mappingNode.Values {
+					if value.Key.GetToken().Value == "service" {
+						chain = append(chain, hierarchyProperties(value.Value.GetToken().Value, serviceProps, chain)...)
+					}
+				}
+			}
+		}
+	}
+	chain = append(chain, serviceProps[service])
+	return chain
+}
+
+func InlayHint(doc document.ComposeDocument, rng protocol.Range) ([]protocol.InlayHint, error) {
+	file := doc.File()
+	if file == nil || len(file.Docs) == 0 {
+		return nil, nil
+	}
+
+	hints := []protocol.InlayHint{}
+	for _, docNode := range file.Docs {
+		if mappingNode, ok := docNode.Body.(*ast.MappingNode); ok {
+			for _, node := range mappingNode.Values {
+				if s, ok := node.Key.(*ast.StringNode); ok && s.Value == "services" {
+					serviceProps := allServiceProperties(node.Value)
+					for service, props := range serviceProps {
+						chain := hierarchyProperties(service, serviceProps, []map[string]ast.Node{})
+						if len(chain) == 1 {
+							continue
+						}
+						slices.Reverse(chain)
+						chain = chain[1:]
+						for name, value := range props {
+							if name == "extends" {
+								continue
+							}
+
+							for _, parentProps := range chain {
+								if parentProp, ok := parentProps[name]; ok {
+									if _, ok := parentProp.(*ast.MappingNode); !ok {
+										length := len(value.GetToken().Value)
+										if value.GetToken().Type == token.DoubleQuoteType {
+											length += 2
+										}
+										hints = append(hints, protocol.InlayHint{
+											Label:       fmt.Sprintf("(parent value: %v)", parentProp.GetToken().Value),
+											PaddingLeft: types.CreateBoolPointer(true),
+											Position: protocol.Position{
+												Line:      uint32(value.GetToken().Position.Line) - 1,
+												Character: uint32(value.GetToken().Position.Column + length - 1),
+											},
+										})
+										break
+									}
+								}
+							}
+						}
+					}
+					break
+				}
+			}
+		}
+	}
+	return hints, nil
+}

--- a/internal/compose/inlayHint_test.go
+++ b/internal/compose/inlayHint_test.go
@@ -1,0 +1,145 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/docker/docker-language-server/internal/types"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
+)
+
+func TestInlayHint(t *testing.T) {
+	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))
+
+	testCases := []struct {
+		name       string
+		content    string
+		inlayHints []protocol.InlayHint
+	}{
+		{
+			name: "extends is ignored",
+			content: `
+services:
+  web:
+    attach: true
+  web2:
+    extends: web
+  web3:
+    extends: web2`,
+			inlayHints: []protocol.InlayHint{},
+		},
+		{
+			name: "single line attribute has a hint",
+			content: `
+services:
+  web:
+    attach: true
+  web2:
+    extends: web
+    attach: false`,
+			inlayHints: []protocol.InlayHint{
+				{
+					Label:       "(parent value: true)",
+					PaddingLeft: types.CreateBoolPointer(true),
+					Position:    protocol.Position{Line: 6, Character: 17},
+				},
+			},
+		},
+		{
+			name: "attribute recurses upwards",
+			content: `
+services:
+  web:
+    attach: true
+  web2:
+    extends: web
+  web3:
+    extends: web
+    attach: false`,
+			inlayHints: []protocol.InlayHint{
+				{
+					Label:       "(parent value: true)",
+					PaddingLeft: types.CreateBoolPointer(true),
+					Position:    protocol.Position{Line: 8, Character: 17},
+				},
+			},
+		},
+		{
+			name: "extends as an object but without a file attribute",
+			content: `
+services:
+  web:
+    attach: true
+  web2:
+    extends:
+      service: web
+    attach: false`,
+			inlayHints: []protocol.InlayHint{
+				{
+					Label:       "(parent value: true)",
+					PaddingLeft: types.CreateBoolPointer(true),
+					Position:    protocol.Position{Line: 7, Character: 17},
+				},
+			},
+		},
+		{
+			name: "extends as an object pointing to a locally named service but points to a bad file",
+			content: `
+services:
+  web:
+    attach: true
+  web2:
+    extends:
+      service: web
+      file: non-existent.yaml
+    attach: false`,
+			inlayHints: []protocol.InlayHint{},
+		},
+		{
+			name: "quoted string value has the correct position",
+			content: `
+services:
+  web:
+    hostname: "hostname1"
+  web2:
+    hostname: "hostname2"
+    extends: web`,
+			inlayHints: []protocol.InlayHint{
+				{
+					Label:       "(parent value: hostname1)",
+					PaddingLeft: types.CreateBoolPointer(true),
+					Position:    protocol.Position{Line: 5, Character: 25},
+				},
+			},
+		},
+		{
+			name: "sub-attributes unsupported",
+			content: `
+services:
+  web:
+    build:
+      context: c1
+  web2:
+    build:
+      context: c2
+    extends: web`,
+			inlayHints: []protocol.InlayHint{},
+		},
+	}
+
+	for _, tc := range testCases {
+		u := uri.URI(composeFileURI)
+		t.Run(tc.name, func(t *testing.T) {
+			doc := document.NewComposeDocument(u, 1, []byte(tc.content))
+			inlayHints, err := InlayHint(doc, protocol.Range{})
+			require.NoError(t, err)
+			require.Equal(t, tc.inlayHints, inlayHints)
+		})
+	}
+}

--- a/internal/pkg/server/inlayHint.go
+++ b/internal/pkg/server/inlayHint.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/compose"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -14,7 +15,9 @@ func (s *Server) TextDocumentInlayHint(ctx *glsp.Context, params *protocol.Inlay
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+		return compose.InlayHint(doc.(document.ComposeDocument), params.Range)
+	} else if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.InlayHint(s.docs, doc.(document.BakeHCLDocument), params.Range)
 	}
 	return nil, nil


### PR DESCRIPTION
Fixes #156.

Object attributes requires further recursion down and will be reviewed in the future.