### PR TITLE
Add support for formatting Compose YAML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to the Docker Language Server will be documented in this fil
     - improve code completion by automatically including required attributes in completion items ([#155](https://github.com/docker/docker-language-server/issues/155))
   - textDocument/inlayHint
     - show the parent service's value if it is being overridden and they are not object attributes ([#156](https://github.com/docker/docker-language-server/issues/156))
+  - textDocument/formatting
+    - add support to format YAML files that do not have clear syntactical errors ([#165](https://github.com/docker/docker-language-server/issues/165))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -16,17 +16,20 @@ The Docker Language Server relies on some features that are dependent on [Buildx
   - code completion
   - code navigation
   - document outline support
+  - formatting
   - highlight named references of services, networks, volumes, configs, and secrets
   - hover tooltips
+  - inlay hints for overridden attribute values
   - open links to images
   - rename preparation
   - rename named references
 - Bake files
   - code completion
-  - inferring variable values
-  - formatting
   - code navigation
+  - document outline support
+  - formatting
   - hover tooltips
+  - inferring variable values
 
 ## Installing
 

--- a/internal/compose/formatting.go
+++ b/internal/compose/formatting.go
@@ -1,0 +1,150 @@
+package compose
+
+import (
+	"strings"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/sourcegraph/jsonrpc2"
+)
+
+type indentation struct {
+	original int
+	desired  int
+}
+
+type comment struct {
+	line       int
+	whitespace int
+}
+
+func formattingOptionTabSize(options protocol.FormattingOptions) (int, error) {
+	if tabSize, ok := options[protocol.FormattingOptionTabSize].(float64); ok && tabSize > 0 {
+		return int(tabSize), nil
+	}
+	return -1, &jsonrpc2.Error{Code: jsonrpc2.CodeInvalidParams, Message: "tabSize is not a positive integer"}
+}
+
+func indent(indentation int) string {
+	sb := strings.Builder{}
+	for range indentation {
+		sb.WriteString(" ")
+	}
+	return sb.String()
+}
+
+func Formatting(doc document.ComposeDocument, options protocol.FormattingOptions) ([]protocol.TextEdit, error) {
+	file := doc.File()
+	if file == nil || len(file.Docs) == 0 {
+		return nil, nil
+	}
+	tabSize, err := formattingOptionTabSize(options)
+	if err != nil {
+		return nil, err
+	}
+
+	edits := []protocol.TextEdit{}
+	indentations := []indentation{}
+	comments := []comment{}
+	topLevelNodeDetected := false
+	lines := strings.Split(string(doc.Input()), "\n")
+lineCheck:
+	for lineNumber, line := range lines {
+		lineIndentation := 0
+		stop := 0
+		isComment := false
+		empty := true
+		for i := range len(line) {
+			if line[i] == 32 {
+				lineIndentation++
+			} else if line[i] == '#' {
+				empty = false
+				isComment = true
+				comments = append(comments, comment{line: lineNumber, whitespace: i})
+				break
+			} else {
+				empty = false
+				if strings.HasPrefix(lines[lineNumber], "---") {
+					edits = append(edits, formatComments(comments, 0)...)
+					comments = nil
+					indentations = nil
+					topLevelNodeDetected = false
+					continue lineCheck
+				}
+
+				if !topLevelNodeDetected {
+					topLevelNodeDetected = true
+					if lineIndentation > 0 {
+						newIndentation, _ := updateIndentation(indentations, lineIndentation, 0)
+						indentations = append(indentations, newIndentation)
+					}
+				}
+				break
+			}
+			stop++
+		}
+
+		if isComment {
+			continue
+		}
+
+		if lineIndentation != 0 {
+			newIndentation, resetIndex := updateIndentation(indentations, lineIndentation, tabSize)
+			if resetIndex == -1 {
+				indentations = append(indentations, newIndentation)
+			} else {
+				indentations = indentations[:resetIndex+1]
+			}
+			edits = append(edits, formatComments(comments, newIndentation.desired)...)
+			comments = nil
+			if lineIndentation != newIndentation.desired {
+				edits = append(edits, protocol.TextEdit{
+					NewText: indent(newIndentation.desired),
+					Range: protocol.Range{
+						Start: protocol.Position{Line: protocol.UInteger(lineNumber), Character: 0},
+						End:   protocol.Position{Line: protocol.UInteger(lineNumber), Character: protocol.UInteger(stop)},
+					},
+				})
+			}
+		} else if !empty {
+			edits = append(edits, formatComments(comments, 0)...)
+			comments = nil
+			indentations = nil
+		}
+	}
+	return edits, nil
+}
+
+// formatComments goes over the list of comments and corrects its
+// indentation to the desired indentation only if it differs. Any
+// comment that needs to have its indentation changed will have a
+// TextEdit created for it and included in the returned result.
+func formatComments(comments []comment, desired int) []protocol.TextEdit {
+	edits := []protocol.TextEdit{}
+	for _, c := range comments {
+		if desired != c.whitespace {
+			edits = append(edits, protocol.TextEdit{
+				NewText: indent(desired),
+				Range: protocol.Range{
+					Start: protocol.Position{Line: protocol.UInteger(c.line), Character: 0},
+					End:   protocol.Position{Line: protocol.UInteger(c.line), Character: protocol.UInteger(c.whitespace)},
+				},
+			})
+		}
+	}
+	return edits
+}
+
+func updateIndentation(indentations []indentation, original, tabSpacing int) (indentation, int) {
+	last := tabSpacing
+	for i := range indentations {
+		if indentations[i].original == original {
+			return indentations[i], i
+		}
+		last = indentations[i].desired + tabSpacing
+	}
+	return indentation{
+		original: original,
+		desired:  last,
+	}, -1
+}

--- a/internal/compose/formatting_test.go
+++ b/internal/compose/formatting_test.go
@@ -1,0 +1,407 @@
+package compose
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/docker/docker-language-server/internal/pkg/document"
+	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
+	"github.com/stretchr/testify/require"
+	"go.lsp.dev/uri"
+)
+
+func TestFormatting(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		edits   []protocol.TextEdit
+	}{
+		{
+			name: "correct indentation of one level indented more than expected",
+			content: `
+services:
+   web:`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "correct indentation of the second level indented less than expected",
+			content: `
+services:
+  web:
+   image: alpine`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "correct indentation of the second level indented more than expected",
+			content: `
+services:
+  web:
+     image: alpine`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 5},
+					},
+				},
+			},
+		},
+		{
+			name: "indentation is reset and can be corrected in future nodes",
+			content: `
+services:
+  web:
+    image: alpine
+
+networks:
+   testNetwork:`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 0},
+						End:   protocol.Position{Line: 6, Character: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "indentation is reset for sub nodes",
+			content: `
+services:
+  web:
+   image: alpine
+  web2:
+      image: alpine`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 3},
+					},
+				},
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 6},
+					},
+				},
+			},
+		},
+		{
+			name: "comment does not reset stored indentations",
+			content: `
+topLevelNode:
+  attribute:
+           # comment
+        # comment
+   attribute2: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 11},
+					},
+				},
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 0},
+						End:   protocol.Position{Line: 4, Character: 8},
+					},
+				},
+				{
+					NewText: "    ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 3},
+					},
+				},
+			},
+		},
+		{
+			name: "comment is formatted even if the node is fine",
+			content: `
+topLevelNode:
+  attribute: true
+           # comment
+  attribute2: false`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 11},
+					},
+				},
+			},
+		},
+		{
+			name: "correct comment is ignored",
+			content: `
+topLevelNode:
+  attribute: true
+  # comment
+  attribute2: false`,
+			edits: []protocol.TextEdit{},
+		},
+		{
+			name: "comment information is reset",
+			content: `
+topLevelNode:
+    # comment
+  attribute: true
+topLevelNode2:
+      # comment
+    attribute: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 4},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 6},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 6, Character: 0},
+						End:   protocol.Position{Line: 6, Character: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "comment pushed to the front",
+			content: `
+topLevelNode:
+  attribute: true
+  # comment
+topLevelNode2:`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 2},
+					},
+				},
+			},
+		},
+		{
+			name: "comments are reset when a comment is pushed to the front",
+			content: `
+topLevelNode:
+  attribute: true
+ # comment
+topLevelNode2:
+    # comment
+  attribute: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 3, Character: 0},
+						End:   protocol.Position{Line: 3, Character: 1},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "top node adjusted",
+			content: `
+# comment
+ topLevelNode:
+  attribute: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 1},
+					},
+				},
+			},
+		},
+		{
+			name: "document separator does not indent if correct",
+			content: `---
+# comment
+topLevelNode:
+  attribute: true`,
+			edits: []protocol.TextEdit{},
+		},
+		{
+			name: "top node adjusted even with a document separator",
+			content: `---
+# comment
+ topLevelNode:
+  attribute: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 1},
+					},
+				},
+			},
+		},
+		{
+			name: "document separator will reset indentations",
+			content: `---
+topLevelNode:
+  attribute: true
+---
+  abc:
+    def: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 0},
+						End:   protocol.Position{Line: 4, Character: 2},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "comments fixed when encountering a document separator",
+			content: `---
+topLevelNode:
+  # comment
+---`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 2},
+					},
+				},
+			},
+		},
+		{
+			name: "comments cleared and reset when encountering a document separator",
+			content: `---
+topLevelNode:
+  # comment
+---
+first:
+    # comment
+  second: true`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 2},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 4},
+					},
+				},
+			},
+		},
+		{
+			name: "top level nodes' indentation remains consistent",
+			content: `
+ topLevelNode:
+   attribute: true
+
+ topAgain:
+   attribute: false`,
+			edits: []protocol.TextEdit{
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 1, Character: 0},
+						End:   protocol.Position{Line: 1, Character: 1},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 2, Character: 0},
+						End:   protocol.Position{Line: 2, Character: 3},
+					},
+				},
+				{
+					NewText: "",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 4, Character: 0},
+						End:   protocol.Position{Line: 4, Character: 1},
+					},
+				},
+				{
+					NewText: "  ",
+					Range: protocol.Range{
+						Start: protocol.Position{Line: 5, Character: 0},
+						End:   protocol.Position{Line: 5, Character: 3},
+					},
+				},
+			},
+		},
+	}
+
+	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))
+	u := uri.URI(composeFileURI)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := document.NewComposeDocument(u, 1, []byte(tc.content))
+			edits, err := Formatting(doc, protocol.FormattingOptions{
+				protocol.FormattingOptionTabSize: float64(2),
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.edits, edits)
+		})
+	}
+}

--- a/internal/pkg/server/formatting.go
+++ b/internal/pkg/server/formatting.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/compose"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -14,7 +15,9 @@ func (s *Server) TextDocumentFormatting(ctx *glsp.Context, params *protocol.Docu
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+		return compose.Formatting(doc.(document.ComposeDocument), params.Options)
+	} else if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Formatting(doc.(document.BakeHCLDocument), params.Options)
 	}
 	return nil, nil

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -261,14 +261,21 @@ func (s *Server) updateTelemetrySetting(value string) {
 // rather than doing it globally.
 func (s *Server) registerFormattingCapability() {
 	dockerbakeLanguage := string(protocol.DockerBakeLanguage)
-	dockerbakeDocumentSelctor := protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockerbakeLanguage}}
+	dockercomposeLanguage := string(protocol.DockerComposeLanguage)
 	s.registerCapability(
 		[]protocol.Registration{
 			{
 				ID:     "docker.lsp.dockerbake.textDocument.formatting",
 				Method: "textDocument/formatting",
 				RegisterOptions: protocol.TextDocumentRegistrationOptions{
-					DocumentSelector: &dockerbakeDocumentSelctor,
+					DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockerbakeLanguage}},
+				},
+			},
+			{
+				ID:     "docker.lsp.dockercompose.textDocument.formatting",
+				Method: "textDocument/formatting",
+				RegisterOptions: protocol.TextDocumentRegistrationOptions{
+					DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockercomposeLanguage}},
 				},
 			},
 		},


### PR DESCRIPTION
This feature will not work if the file has clear, syntactical errors that prevents goccy/go-yaml from parsing the file.

Fixes #165.