### PR TITLE
React to configuration change events for Scout

### DIFF
--- a/e2e-tests/didChangeConfiguration_test.go
+++ b/e2e-tests/didChangeConfiguration_test.go
@@ -3,7 +3,6 @@ package server_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -14,10 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createDidChangeConfiguration() protocol.DidChangeConfigurationParams {
-	return protocol.DidChangeConfigurationParams{
-		Settings: []string{"docker.lsp.experimental.vulnerabilityScanning"},
-	}
+func createDidChangeConfiguration(setting string) protocol.DidChangeConfigurationParams {
+	return protocol.DidChangeConfigurationParams{Settings: []string{setting}}
 }
 
 func TestDidChangeConfiguration(t *testing.T) {
@@ -31,28 +28,120 @@ func TestDidChangeConfiguration(t *testing.T) {
 
 	clientStream := jsonrpc2.NewBufferedStream(&TestStream{incoming: client, outgoing: server, closed: false}, jsonrpc2.VSCodeObjectCodec{})
 	defer clientStream.Close()
-	handler := &ConfigurationHandler{t: t, scanning: false}
+	handler := &ConfigurationHandler{t: t, experimental: configuration.Experimental{VulnerabilityScanning: false}}
 	conn := jsonrpc2.NewConn(context.Background(), clientStream, handler)
 	initialize(t, conn, protocol.InitializeParams{})
 
 	homedir, err := os.UserHomeDir()
 	require.NoError(t, err)
 
+	// when a file is opened, verify that configuration is fetched
 	didOpen := createDidOpenTextDocumentParams(homedir, "Dockerfile", "FROM scratch", protocol.DockerfileLanguage)
+	handler.handled = false
 	err = conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
 	require.NoError(t, err)
-
-	for configuration.Get(didOpen.TextDocument.URI).Experimental.VulnerabilityScanning {
-		fmt.Fprintln(os.Stderr, "Sleeping...")
+	for !handler.handled || configuration.Get(didOpen.TextDocument.URI).Experimental.VulnerabilityScanning {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	handler.scanning = true
-	didChangeConfiguration := createDidChangeConfiguration()
+	testCases := []struct {
+		name           string
+		changedSetting string
+		experimental   configuration.Experimental
+	}{
+		{
+			name:           "vulnerabilityScanning=true",
+			changedSetting: "docker.lsp.experimental.vulnerabilityScanning",
+			experimental: configuration.Experimental{
+				VulnerabilityScanning: true,
+				Scout: configuration.Scout{
+					CriticalHighVulnerabilities: false,
+					NotPinnedDigest:             false,
+					RecommendedTag:              false,
+					Vulnerabilites:              false,
+				},
+			},
+		},
+		{
+			name:           "vulnerabilityScanning=true,criticalHighVulnerabilities=true",
+			changedSetting: "docker.lsp.experimental.scout.criticalHighVulnerabilities",
+			experimental: configuration.Experimental{
+				VulnerabilityScanning: true,
+				Scout: configuration.Scout{
+					CriticalHighVulnerabilities: true,
+					NotPinnedDigest:             false,
+					RecommendedTag:              false,
+					Vulnerabilites:              false,
+				},
+			},
+		},
+		{
+			name:           "vulnerabilityScanning=true,notPinnedDigest=true",
+			changedSetting: "docker.lsp.experimental.scout.notPinnedDigest",
+			experimental: configuration.Experimental{
+				VulnerabilityScanning: true,
+				Scout: configuration.Scout{
+					CriticalHighVulnerabilities: false,
+					NotPinnedDigest:             true,
+					RecommendedTag:              false,
+					Vulnerabilites:              false,
+				},
+			},
+		},
+		{
+			name:           "vulnerabilityScanning=true,recommendedTag=true",
+			changedSetting: "docker.lsp.experimental.scout.recommendedTag",
+			experimental: configuration.Experimental{
+				VulnerabilityScanning: true,
+				Scout: configuration.Scout{
+					CriticalHighVulnerabilities: false,
+					NotPinnedDigest:             false,
+					RecommendedTag:              true,
+					Vulnerabilites:              false,
+				},
+			},
+		},
+		{
+			name:           "vulnerabilityScanning=true,vulnerabilities=true",
+			changedSetting: "docker.lsp.experimental.scout.vulnerabilities",
+			experimental: configuration.Experimental{
+				VulnerabilityScanning: true,
+				Scout: configuration.Scout{
+					CriticalHighVulnerabilities: false,
+					NotPinnedDigest:             false,
+					RecommendedTag:              false,
+					Vulnerabilites:              true,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			configuration.Store(
+				didOpen.TextDocument.URI,
+				configuration.Configuration{
+					Experimental: configuration.Experimental{VulnerabilityScanning: false},
+				},
+			)
+			handler.handled = false
+			handler.experimental = tc.experimental
+
+			didChangeConfiguration := createDidChangeConfiguration(tc.changedSetting)
+			err = conn.Notify(context.Background(), protocol.MethodWorkspaceDidChangeConfiguration, didChangeConfiguration)
+			require.NoError(t, err)
+			for !handler.handled || !configuration.Get(didOpen.TextDocument.URI).Experimental.VulnerabilityScanning {
+				time.Sleep(100 * time.Millisecond)
+			}
+			require.Equal(t, tc.experimental, configuration.Get(didOpen.TextDocument.URI).Experimental)
+		})
+	}
+
+	handler.handled = false
+	didChangeConfiguration := createDidChangeConfiguration(configuration.ConfigTelemetry)
 	err = conn.Notify(context.Background(), protocol.MethodWorkspaceDidChangeConfiguration, didChangeConfiguration)
 	require.NoError(t, err)
-	for !configuration.Get(didOpen.TextDocument.URI).Experimental.VulnerabilityScanning {
+	for !handler.handled {
 		time.Sleep(100 * time.Millisecond)
 	}
-	require.True(t, configuration.Get(didOpen.TextDocument.URI).Experimental.VulnerabilityScanning)
 }

--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/configuration"
 	"github.com/docker/docker-language-server/internal/pkg/buildkit"
 	"github.com/docker/docker-language-server/internal/pkg/cli/metadata"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
@@ -34,7 +35,15 @@ func (h *PublishDiagnosticsHandler) Handle(_ context.Context, conn *jsonrpc2.Con
 		}
 	case protocol.ServerWorkspaceConfiguration:
 		if !request.Notif && request.Params != nil {
-			HandleConfiguration(h.t, conn, request, true)
+			HandleConfiguration(
+				h.t,
+				conn,
+				request,
+				configuration.Experimental{
+					VulnerabilityScanning: true,
+					Scout:                 configuration.Get("/tmp/non-existent-file-to-get-default-config").Experimental.Scout,
+				},
+			)
 		}
 	}
 }

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -6,8 +6,16 @@ import (
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 )
 
-const ConfigTelemetry = "docker.lsp.telemetry"
-const ConfigExperimentalVulnerabilityScanning = "docker.lsp.experimental.vulnerabilityScanning"
+const (
+	ConfigTelemetry = "docker.lsp.telemetry"
+
+	ConfigExperimentalVulnerabilityScanning = "docker.lsp.experimental.vulnerabilityScanning"
+
+	ConfigExperimentalScoutCriticalHighVulnerabilities = "docker.lsp.experimental.scout.criticalHighVulnerabilities"
+	ConfigExperimentalScoutNotPinnedDigest             = "docker.lsp.experimental.scout.notPinnedDigest"
+	ConfigExperimentalScoutRecommendedTag              = "docker.lsp.experimental.scout.recommendedTag"
+	ConfigExperimentalScoutVulnerabilities             = "docker.lsp.experimental.scout.vulnerabilities"
+)
 
 type TelemetrySetting string
 


### PR DESCRIPTION
When we receive a notification from the client about Scout configuration changes, we should react to them and ask the client to send us the new configuration values.