### PR TITLE
Rescan a Dockerfile if flags have changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
- ## [0.8.0] - 2025-05-23
+## [Unreleased]
+
+### Fixed
+
+- Dockerfile
+  - textDocument/publishDiagnostics
+    - consider flag changes when determining whether to scan a file again or not ([#224](https://github.com/docker/docker-language-server/issues/224))
+
+## [0.8.0] - 2025-05-23
 
 ### Added
 

--- a/e2e-tests/documentLink_test.go
+++ b/e2e-tests/documentLink_test.go
@@ -91,9 +91,11 @@ func TestDocumentLink(t *testing.T) {
 	err = conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
 	require.NoError(t, err)
 
+	version := int32(2)
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			didChange := createDidChangeTextDocumentParams(testFolder, "DocumentLink.hcl", tc.content)
+			didChange := createDidChangeTextDocumentParams(testFolder, "DocumentLink.hcl", tc.content, version)
+			version++
 			err = conn.Notify(context.Background(), protocol.MethodTextDocumentDidChange, didChange)
 			require.NoError(t, err)
 

--- a/e2e-tests/initialize_test.go
+++ b/e2e-tests/initialize_test.go
@@ -33,13 +33,13 @@ func createDidOpenTextDocumentParams(homedir, testName, text string, languageID 
 	}
 }
 
-func createDidChangeTextDocumentParams(homedir, testName, text string) protocol.DidChangeTextDocumentParams {
+func createDidChangeTextDocumentParams(homedir, testName, text string, version int32) protocol.DidChangeTextDocumentParams {
 	return protocol.DidChangeTextDocumentParams{
 		TextDocument: protocol.VersionedTextDocumentIdentifier{
 			TextDocumentIdentifier: protocol.TextDocumentIdentifier{
 				URI: protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(homedir, testName)), "/"))),
 			},
-			Version: 1,
+			Version: version,
 		},
 		ContentChanges: []any{
 			protocol.TextDocumentContentChangeEvent{

--- a/internal/pkg/document/dockerfileDocument.go
+++ b/internal/pkg/document/dockerfileDocument.go
@@ -91,6 +91,16 @@ func (d *dockerfileDocument) parse(force bool) bool {
 }
 
 func compareNodes(n1, n2 *parser.Node) bool {
+	if len(n1.Flags) != len(n2.Flags) {
+		return true
+	}
+
+	for i := range n1.Flags {
+		if n1.Flags[i] != n2.Flags[i] {
+			return true
+		}
+	}
+
 	for {
 		if n1 == nil {
 			return n2 != nil

--- a/internal/pkg/document/dockerfileDocument_test.go
+++ b/internal/pkg/document/dockerfileDocument_test.go
@@ -1,0 +1,37 @@
+package document
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	testCases := []struct {
+		name       string
+		content    string
+		newContent string
+		result     bool
+	}{
+		{
+			name:       "flag added",
+			content:    "FROM scratch",
+			newContent: "FROM --platform=abc scratch",
+			result:     true,
+		},
+		{
+			name:       "flag value changed",
+			content:    "FROM --platform=abc scratch",
+			newContent: "FROM --platform=abcd scratch",
+			result:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := NewDockerfileDocument("file:///tmp/Dockerfile", 1, []byte(tc.content))
+			result := doc.Update(2, []byte(tc.newContent))
+			require.Equal(t, tc.result, result)
+		})
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -16,6 +16,10 @@ func CreateBoolPointer(b bool) *bool {
 	return &b
 }
 
+func CreateInt32Pointer(i int32) *int32 {
+	return &i
+}
+
 func CreateStringPointer(s string) *string {
 	return &s
 }


### PR DESCRIPTION
We originally only considered the instruction and its arguments when deciding whether to rescan a Dockerfile. We should also trigger a rescan if any of the flags on an instruction has changed.

Fixes #224.