### PR TITLE
Hide tag recommendations by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ## [Unreleased]
 
+### Changed
+
+- Dockerfile
+  - textDocument/hover
+    - `recommended_tag` diagnostics are now hidden by default ([#223](https://github.com/docker/docker-language-server/issues/223))
+  - textDocument/publishDiagnostics
+    - recommended tag hovers are now hidden by default ([#223](https://github.com/docker/docker-language-server/issues/223))
+
 ### Fixed
 
 - Dockerfile

--- a/e2e-tests/hover_test.go
+++ b/e2e-tests/hover_test.go
@@ -87,7 +87,7 @@ func TestHover(t *testing.T) {
 			result: &protocol.Hover{
 				Contents: protocol.MarkupContent{
 					Kind:  protocol.MarkupKindMarkdown,
-					Value: "Current image vulnerabilities:   1C   3H   9M   0L \r\n\r\nRecommended tags:\n\n<table>\n<tr><td><code>3.21.3</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.20.6</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.18.12</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n</table>\n",
+					Value: "Current image vulnerabilities:   1C   3H   9M   0L ",
 				},
 			},
 		},

--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -216,30 +216,6 @@ func testPublishDiagnostics(t *testing.T, initializeParams protocol.InitializePa
 						End:   protocol.Position{Line: 0, Character: 18},
 					},
 				},
-				{
-					Message:  "Tag recommendations available",
-					Source:   types.CreateStringPointer("docker-language-server"),
-					Code:     &protocol.IntegerOrString{Value: "recommended_tag"},
-					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityInformation),
-					Range: protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 0},
-						End:   protocol.Position{Line: 0, Character: 18},
-					},
-					Data: []any{
-						map[string]any{
-							"edit":  "FROM alpine:3.21.3",
-							"title": "Update image to preferred tag (3.21.3)",
-						},
-						map[string]any{
-							"edit":  "FROM alpine:3.20.6",
-							"title": "Update image OS minor version (3.20.6)",
-						},
-						map[string]any{
-							"edit":  "FROM alpine:3.18.12",
-							"title": "Update image OS minor version (3.18.12)",
-						},
-					},
-				},
 			},
 		},
 	}

--- a/internal/configuration/configuration.go
+++ b/internal/configuration/configuration.go
@@ -54,7 +54,7 @@ var defaultConfiguration = Configuration{
 		Scout: Scout{
 			CriticalHighVulnerabilities: true,
 			NotPinnedDigest:             false,
-			RecommendedTag:              true,
+			RecommendedTag:              false,
 			Vulnerabilites:              true,
 		},
 	},

--- a/internal/scout/service_test.go
+++ b/internal/scout/service_test.go
@@ -56,30 +56,6 @@ func TestCalculateDiagnostics(t *testing.T) {
 					},
 					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityWarning),
 				},
-				{
-					Message: "Tag recommendations available",
-					Code:    &protocol.IntegerOrString{Value: "recommended_tag"},
-					Source:  types.CreateStringPointer("scout-testing-source"),
-					Range: protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 0},
-						End:   protocol.Position{Line: 0, Character: 18},
-					},
-					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityInformation),
-					Data: []types.NamedEdit{
-						{
-							Title: "Update image to preferred tag (3.21.3)",
-							Edit:  "FROM alpine:3.21.3",
-						},
-						{
-							Title: "Update image OS minor version (3.20.6)",
-							Edit:  "FROM alpine:3.20.6",
-						},
-						{
-							Title: "Update image OS minor version (3.18.12)",
-							Edit:  "FROM alpine:3.18.12",
-						},
-					},
-				},
 			},
 		},
 		{
@@ -98,30 +74,6 @@ func TestCalculateDiagnostics(t *testing.T) {
 						End:   protocol.Position{Line: 0, Character: 44},
 					},
 					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityWarning),
-				},
-				{
-					Message: "Tag recommendations available",
-					Code:    &protocol.IntegerOrString{Value: "recommended_tag"},
-					Source:  types.CreateStringPointer("scout-testing-source"),
-					Range: protocol.Range{
-						Start: protocol.Position{Line: 0, Character: 0},
-						End:   protocol.Position{Line: 0, Character: 44},
-					},
-					Severity: types.CreateDiagnosticSeverityPointer(protocol.DiagnosticSeverityInformation),
-					Data: []types.NamedEdit{
-						{
-							Title: "Update image to preferred tag (3.21.3)",
-							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.21.3",
-						},
-						{
-							Title: "Update image OS minor version (3.20.6)",
-							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.20.6",
-						},
-						{
-							Title: "Update image OS minor version (3.18.12)",
-							Edit:  "FROM --platform=$BUILDPLATFORM alpine:3.18.12",
-						},
-					},
 				},
 			},
 		},
@@ -210,14 +162,12 @@ func TestCalculateDiagnostics_IgnoresSpecifics(t *testing.T) {
 			content: "FROM alpine:3.16.1",
 			codes: []string{
 				"critical_high_vulnerabilities",
-				"recommended_tag",
 			},
 		},
 		{
 			name:    "ubuntu:24.04",
 			content: "FROM ubuntu:24.04",
 			codes: []string{
-				"recommended_tag",
 				"vulnerabilities",
 			},
 		},
@@ -326,7 +276,7 @@ func TestGetHovers(t *testing.T) {
 			result: &protocol.Hover{
 				Contents: protocol.MarkupContent{
 					Kind:  protocol.MarkupKindMarkdown,
-					Value: "Current image vulnerabilities:   1C   3H   9M   0L \r\n\r\nRecommended tags:\n\n<table>\n<tr><td><code>3.21.3</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.20.6</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n<tr><td><code>3.18.12</code></td><td align=\"right\">  0C</td><td align=\"right\">  0H</td><td align=\"right\">  0M</td><td align=\"right\">  0L</td><td align=\"right\"></td></tr>\n</table>\n",
+					Value: "Current image vulnerabilities:   1C   3H   9M   0L ",
 				},
 			},
 		},


### PR DESCRIPTION
Tag recommendations in diagnostics and hovers are now disabled by default.

Fixes #223.