### PR TITLE
Allow Compose support to be disabled on initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ## [Unreleased]
 
+## Added
+
+- global initialization option to disable all Compose features ([#230](https://github.com/docker/docker-language-server/issues/230))
+
 ### Fixed
 
 - Dockerfile

--- a/README.md
+++ b/README.md
@@ -86,10 +86,14 @@ Use "docker-language-server [command] --help" for more information about a comma
 On startup, the client can include initialization options on the initial `initialize` request.
 1. If the client is also using [rcjsuen/dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server), then some results in `textDocument/publishDiagnostics` will be duplicated across the two language servers. By setting the _experimental_ `dockerfileExperimental.removeOverlappingIssues` to `true`, the Docker Language Server will suppress the duplicated results. Note that this setting may be renamed or removed at any time.
 2. Telemetry can be configured on server startup with the `telemetry` field. You can read more about this in [TELEMETRY.md](./TELEMETRY.md).
+3. Compose support can be disabled on server initialization by setting the _experimental_ `dockercomposeExperimental.composeSupport` attribute to `false`. The default value is `true`.
 
 ```JSONC
 {
   "initializationOptions": {
+    "dockercomposeExperimental": {
+      "composeSupport:": true | false
+    },
     "dockerfileExperimental": {
       "removeOverlappingIssues:": true | false
     },

--- a/e2e-tests/completion_test.go
+++ b/e2e-tests/completion_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCompletion(t *testing.T) {
+func TestCompletion_Bake(t *testing.T) {
 	s := startServer()
 
 	client := bytes.NewBuffer(make([]byte, 0, 1024))
@@ -100,7 +101,7 @@ func TestCompletion(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".hcl", tc.content, "dockerbake")
+			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".hcl", tc.content, protocol.DockerBakeLanguage)
 			err := conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
 			require.NoError(t, err)
 
@@ -114,6 +115,105 @@ func TestCompletion(t *testing.T) {
 			require.NoError(t, err)
 			require.False(t, result.IsIncomplete)
 			require.Equal(t, tc.items, result.Items)
+		})
+	}
+}
+
+func TestCompletion_Compose(t *testing.T) {
+	testCompletion_Compose(t, true)
+	testCompletion_Compose(t, false)
+}
+
+func testCompletion_Compose(t *testing.T, composeSupport bool) {
+	s := startServer()
+
+	client := bytes.NewBuffer(make([]byte, 0, 1024))
+	server := bytes.NewBuffer(make([]byte, 0, 1024))
+	serverStream := &TestStream{incoming: server, outgoing: client, closed: false}
+	defer serverStream.Close()
+	go s.ServeStream(serverStream)
+
+	clientStream := jsonrpc2.NewBufferedStream(&TestStream{incoming: client, outgoing: server, closed: false}, jsonrpc2.VSCodeObjectCodec{})
+	defer clientStream.Close()
+	conn := jsonrpc2.NewConn(context.Background(), clientStream, &ConfigurationHandler{t: t})
+	initialize(t, conn, protocol.InitializeParams{
+		InitializationOptions: map[string]any{
+			"dockercomposeExperimental": map[string]bool{"composeSupport": composeSupport},
+		},
+	})
+
+	homedir, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name      string
+		content   string
+		line      uint32
+		character uint32
+		items     []protocol.CompletionItem
+	}{
+		{
+			name:      "empty file",
+			content:   "",
+			line:      0,
+			character: 0,
+			items: []protocol.CompletionItem{
+				{
+					Label:         "configs",
+					Documentation: "Configurations that are shared among multiple services.",
+				},
+				{
+					Label:         "include",
+					Documentation: "compose sub-projects to be included.",
+				},
+				{
+					Label:         "name",
+					Documentation: "define the Compose project name, until user defines one explicitly.",
+				},
+				{
+					Label:         "networks",
+					Documentation: "Networks that are shared among multiple services.",
+				},
+				{
+					Label:         "secrets",
+					Documentation: "Secrets that are shared among multiple services.",
+				},
+				{
+					Label:         "services",
+					Documentation: "The services that will be used by your application.",
+				},
+				{
+					Label:         "version",
+					Documentation: "declared for backward compatibility, ignored. Please remove it.",
+				},
+				{
+					Label:         "volumes",
+					Documentation: "Named volumes that are shared among multiple services.",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%v (composeSupport=%v)", tc.name, composeSupport), func(t *testing.T) {
+			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".yaml", tc.content, protocol.DockerComposeLanguage)
+			err := conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
+			require.NoError(t, err)
+
+			var result *protocol.CompletionList
+			err = conn.Call(context.Background(), protocol.MethodTextDocumentCompletion, protocol.CompletionParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: didOpen.TextDocument.URI},
+					Position:     protocol.Position{Line: 0, Character: 0},
+				},
+			}, &result)
+			require.NoError(t, err)
+			if composeSupport {
+				require.False(t, result.IsIncomplete)
+				require.Equal(t, tc.items, result.Items)
+			} else {
+				require.Nil(t, result)
+			}
 		})
 	}
 }

--- a/e2e-tests/rename_test.go
+++ b/e2e-tests/rename_test.go
@@ -3,6 +3,7 @@ package server_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -12,6 +13,11 @@ import (
 )
 
 func TestRename(t *testing.T) {
+	testRename(t, true)
+	testRename(t, false)
+}
+
+func testRename(t *testing.T, composeSupport bool) {
 	s := startServer()
 
 	client := bytes.NewBuffer(make([]byte, 0, 1024))
@@ -23,7 +29,11 @@ func TestRename(t *testing.T) {
 	clientStream := jsonrpc2.NewBufferedStream(&TestStream{incoming: client, outgoing: server, closed: false}, jsonrpc2.VSCodeObjectCodec{})
 	defer clientStream.Close()
 	conn := jsonrpc2.NewConn(context.Background(), clientStream, &ConfigurationHandler{t: t})
-	initialize(t, conn, protocol.InitializeParams{})
+	initialize(t, conn, protocol.InitializeParams{
+		InitializationOptions: map[string]any{
+			"dockercomposeExperimental": map[string]bool{"composeSupport": composeSupport},
+		},
+	})
 
 	homedir, err := os.UserHomeDir()
 	require.NoError(t, err)
@@ -69,8 +79,8 @@ services:
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".yaml", tc.content, "dockercompose")
+		t.Run(fmt.Sprintf("%v (composeSupport=%v)", tc.name, composeSupport), func(t *testing.T) {
+			didOpen := createDidOpenTextDocumentParams(homedir, t.Name()+".yaml", tc.content, protocol.DockerComposeLanguage)
 			err := conn.Notify(context.Background(), protocol.MethodTextDocumentDidOpen, didOpen)
 			require.NoError(t, err)
 
@@ -83,7 +93,11 @@ services:
 				NewName: "newName",
 			}, &workspaceEdit)
 			require.NoError(t, err)
-			require.Equal(t, tc.workspaceEdit(didOpen.TextDocument.URI), workspaceEdit)
+			if composeSupport {
+				require.Equal(t, tc.workspaceEdit(didOpen.TextDocument.URI), workspaceEdit)
+			} else {
+				require.Nil(t, workspaceEdit)
+			}
 		})
 	}
 }

--- a/internal/pkg/server/completion.go
+++ b/internal/pkg/server/completion.go
@@ -18,7 +18,7 @@ func (s *Server) TextDocumentCompletion(ctx *glsp.Context, params *protocol.Comp
 
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Completion(ctx.Context, params, s.docs, doc.(document.BakeHCLDocument))
-	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeCompletion {
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport && s.composeCompletion {
 		return compose.Completion(ctx.Context, params, s.docs, doc.(document.ComposeDocument))
 	}
 	return nil, nil

--- a/internal/pkg/server/definition.go
+++ b/internal/pkg/server/definition.go
@@ -18,7 +18,7 @@ func (s *Server) TextDocumentDefinition(ctx *glsp.Context, params *protocol.Defi
 
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Definition(ctx.Context, s.definitionLinkSupport, s.docs, uri.URI(params.TextDocument.URI), doc.(document.BakeHCLDocument), params.Position)
-	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.Definition(ctx.Context, s.definitionLinkSupport, doc.(document.ComposeDocument), params)
 	}
 	return nil, nil

--- a/internal/pkg/server/documentHighlight.go
+++ b/internal/pkg/server/documentHighlight.go
@@ -17,7 +17,7 @@ func (s *Server) TextDocumentDocumentHighlight(ctx *glsp.Context, params *protoc
 	defer doc.Close()
 	if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.DocumentHighlight(doc.(document.BakeHCLDocument), params.Position)
-	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	} else if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.DocumentHighlight(doc.(document.ComposeDocument), params.Position)
 	}
 	return nil, nil

--- a/internal/pkg/server/documentLink.go
+++ b/internal/pkg/server/documentLink.go
@@ -18,7 +18,7 @@ func (s *Server) TextDocumentDocumentLink(ctx *glsp.Context, params *protocol.Do
 	language := doc.LanguageIdentifier()
 	if language == protocol.DockerBakeLanguage {
 		return hcl.DocumentLink(ctx.Context, params.TextDocument.URI, doc.(document.BakeHCLDocument))
-	} else if language == protocol.DockerComposeLanguage {
+	} else if language == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.DocumentLink(ctx.Context, params.TextDocument.URI, doc.(document.ComposeDocument))
 	}
 	return nil, nil

--- a/internal/pkg/server/documentSymbol.go
+++ b/internal/pkg/server/documentSymbol.go
@@ -18,7 +18,7 @@ func (s *Server) TextDocumentDocumentSymbol(ctx *glsp.Context, params *protocol.
 	language := doc.LanguageIdentifier()
 	if language == protocol.DockerBakeLanguage {
 		return hcl.DocumentSymbol(ctx.Context, string(params.TextDocument.URI), doc.(document.BakeHCLDocument))
-	} else if language == protocol.DockerComposeLanguage {
+	} else if language == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.DocumentSymbol(ctx.Context, doc.(document.ComposeDocument))
 	}
 

--- a/internal/pkg/server/formatting.go
+++ b/internal/pkg/server/formatting.go
@@ -15,7 +15,7 @@ func (s *Server) TextDocumentFormatting(ctx *glsp.Context, params *protocol.Docu
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.Formatting(doc.(document.ComposeDocument), params.Options)
 	} else if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.Formatting(doc.(document.BakeHCLDocument), params.Options)

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -34,8 +34,11 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 		}
 
 		if settings, ok := clientConfig["dockercomposeExperimental"].(map[string]any); ok {
+			if composeSupport, ok := settings["composeSupport"].(bool); ok {
+				s.composeSupport = composeSupport
+			}
 			if composeCompletion, ok := settings["composeCompletion"].(bool); ok {
-				s.composeCompletion = composeCompletion
+				s.composeCompletion = s.composeSupport && composeCompletion
 			}
 		}
 

--- a/internal/pkg/server/inlayHint.go
+++ b/internal/pkg/server/inlayHint.go
@@ -15,7 +15,7 @@ func (s *Server) TextDocumentInlayHint(ctx *glsp.Context, params *protocol.Inlay
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.InlayHint(doc.(document.ComposeDocument), params.Range)
 	} else if doc.LanguageIdentifier() == protocol.DockerBakeLanguage {
 		return hcl.InlayHint(s.docs, doc.(document.BakeHCLDocument), params.Range)

--- a/internal/pkg/server/prepareRename.go
+++ b/internal/pkg/server/prepareRename.go
@@ -14,7 +14,7 @@ func (s *Server) TextDocumentPrepareRename(ctx *glsp.Context, params *protocol.P
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.PrepareRename(doc.(document.ComposeDocument), params)
 	}
 	return nil, nil

--- a/internal/pkg/server/rename.go
+++ b/internal/pkg/server/rename.go
@@ -14,7 +14,7 @@ func (s *Server) TextDocumentRename(ctx *glsp.Context, params *protocol.RenamePa
 		return nil, err
 	}
 	defer doc.Close()
-	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage {
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && s.composeSupport {
 		return compose.Rename(doc.(document.ComposeDocument), params)
 	}
 	return nil, nil

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -66,6 +66,7 @@ type Server struct {
 	// within that Git folder.
 	analyzedFiles map[string]map[string]bool
 
+	composeSupport    bool
 	composeCompletion bool
 
 	mutex sync.RWMutex
@@ -87,6 +88,7 @@ func NewServer(docManager *document.Manager) *Server {
 		telemetry:                  telemetry.NewClient(),
 		scoutService:               scoutService,
 		sessionTelemetryProperties: sessionTelemetryProperties,
+		composeSupport:             true,
 		composeCompletion:          true,
 		diagnosticsCollectors: []textdocument.DiagnosticsCollector{
 			buildkit.NewBuildKitDiagnosticsCollector(),

--- a/internal/pkg/server/text_document_sync.go
+++ b/internal/pkg/server/text_document_sync.go
@@ -72,6 +72,10 @@ func (s *Server) computeDiagnostics(ctx context.Context, documentURI protocol.Do
 		}
 	}
 
+	if doc.LanguageIdentifier() == protocol.DockerComposeLanguage && !s.composeSupport {
+		return
+	}
+
 	s.docs.Queue(ctx, uri.URI(documentURI), func() {
 		defer s.handlePanic("computeDiagnostics")
 		if !s.docs.LockDocument(uri.URI(documentURI)) {


### PR DESCRIPTION
We are introducing an _experimental_ option to disable all Compose features on initialization to prevent conflicts and duplicates with editors that provide their own native Compose editing features.

We will monitor community feedback as this rolls out to understand and iterate on this further as we learn more.

Fixes #230.