### PR TITLE
Fix handling of clients that do not support dynamic registrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- correct initialize request handling for clients that do not support dynamic registrations ([#229](https://github.com/docker/docker-language-server/issues/229))
 - Dockerfile
   - textDocument/hover
     - hide vulnerability hovers if the top level setting is disabled ([#226](https://github.com/docker/docker-language-server/issues/226))

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 
 test:
 	gotestsum -- $$(go list ./... | grep -v e2e-tests) -timeout 30s
-	go test $$(go list ./... | grep e2e-tests) -timeout 180s
+	go test $$(go list ./... | grep e2e-tests) -timeout 240s
 
 build-docker-test:
 	docker build -t docker/lsp:test --target test .

--- a/e2e-tests/initialize_test.go
+++ b/e2e-tests/initialize_test.go
@@ -2,6 +2,9 @@ package server_test
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -10,16 +13,56 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/docker-language-server/internal/bake/hcl"
+	"github.com/docker/docker-language-server/internal/pkg/cli/metadata"
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/pkg/server"
 	"github.com/docker/docker-language-server/internal/tliron/glsp"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
+	"github.com/sourcegraph/jsonrpc2"
 	"github.com/stretchr/testify/require"
 )
 
 func init() {
 	os.Setenv("DOCKER_LANGUAGE_SERVER_TELEMETRY", "false")
+}
+
+type TestStream struct {
+	incoming *bytes.Buffer
+	outgoing *bytes.Buffer
+	closed   bool
+}
+
+func (ts *TestStream) Read(b []byte) (int, error) {
+	for {
+		if ts.closed {
+			return 0, io.EOF
+		}
+
+		r, err := ts.incoming.Read(b)
+		if r > 0 {
+			return r, err
+		} else if err != io.EOF {
+			return r, err
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+func (ts *TestStream) Write(n []byte) (int, error) {
+	return ts.outgoing.Write(n)
+}
+
+func (ts *TestStream) Close() error {
+	ts.closed = true
+	return nil
+}
+
+func startServer() *server.Server {
+	docManager := document.NewDocumentManager()
+	s := server.NewServer(docManager)
+	return s
 }
 
 func createDidOpenTextDocumentParams(homedir, testName, text string, languageID protocol.LanguageIdentifier) protocol.DidOpenTextDocumentParams {
@@ -47,6 +90,61 @@ func createDidChangeTextDocumentParams(homedir, testName, text string, version i
 			},
 		},
 	}
+}
+
+func createGuaranteedInitializeResult() protocol.InitializeResult {
+	syncKind := protocol.TextDocumentSyncKindFull
+	return protocol.InitializeResult{
+		Capabilities: protocol.ServerCapabilities{
+			CodeActionProvider:        protocol.CodeActionOptions{},
+			CompletionProvider:        &protocol.CompletionOptions{},
+			DefinitionProvider:        protocol.DefinitionOptions{},
+			DocumentHighlightProvider: &protocol.DocumentHighlightOptions{},
+			DocumentLinkProvider:      &protocol.DocumentLinkOptions{},
+			DocumentSymbolProvider:    protocol.DocumentSymbolOptions{},
+			ExecuteCommandProvider: &protocol.ExecuteCommandOptions{
+				Commands: []string{types.TelemetryCallbackCommandId},
+			},
+			HoverProvider:            protocol.HoverOptions{},
+			InlayHintProvider:        protocol.InlayHintOptions{},
+			InlineCompletionProvider: protocol.InlineCompletionOptions{},
+			SemanticTokensProvider: protocol.SemanticTokensOptions{
+				Legend: protocol.SemanticTokensLegend{
+					TokenModifiers: []string{},
+					TokenTypes:     hcl.SemanticTokenTypes,
+				},
+				Full:  true,
+				Range: false,
+			},
+			TextDocumentSync: protocol.TextDocumentSyncOptions{
+				OpenClose: &protocol.True,
+				Change:    &syncKind,
+			},
+		},
+		ServerInfo: &protocol.InitializeResultServerInfo{
+			Name:    "docker-language-server",
+			Version: &metadata.Version,
+		},
+	}
+}
+
+func initialize(t *testing.T, conn *jsonrpc2.Conn, initializeParams protocol.InitializeParams) {
+	expected := createGuaranteedInitializeResult()
+	expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+	expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+	initializeCheck(t, conn, initializeParams, expected)
+}
+
+func initializeCheck(t *testing.T, conn *jsonrpc2.Conn, initializeParams protocol.InitializeParams, expected protocol.InitializeResult) {
+	if options, ok := initializeParams.InitializationOptions.(map[string]any); ok {
+		options["telemetry"] = "off"
+	} else {
+		initializeParams.InitializationOptions = map[string]string{"telemetry": "off"}
+	}
+	var initializeResult *protocol.InitializeResult
+	err := conn.Call(context.Background(), protocol.MethodInitialize, initializeParams, &initializeResult)
+	require.NoError(t, err)
+	requireJsonEqual(t, expected, initializeResult)
 }
 
 func TestInitializeFunctionIsolatedCall(t *testing.T) {
@@ -99,39 +197,236 @@ func testInitialize(t *testing.T, initializeParams protocol.InitializeParams) *s
 	return s
 }
 
-type TestStream struct {
-	incoming *bytes.Buffer
-	outgoing *bytes.Buffer
-	closed   bool
-}
+func TestInitialize(t *testing.T) {
+	testCases := []struct {
+		name   string
+		params protocol.InitializeParams
+		result func() protocol.InitializeResult
+	}{
+		{
+			name: "dynamic formatting support not declared",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Formatting: &protocol.DocumentFormattingClientCapabilities{},
+					},
+				},
+			},
+			result: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+		},
+		{
+			name: "dynamic formatting support false",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Formatting: &protocol.DocumentFormattingClientCapabilities{DynamicRegistration: types.CreateBoolPointer(false)},
+					},
+				},
+			},
+			result: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+		},
+		{
+			name: "dynamic rename support not declared",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Rename: &protocol.RenameClientCapabilities{},
+					},
+				},
+			},
+			result: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+		},
+		{
+			name: "dynamic rename support false",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Rename: &protocol.RenameClientCapabilities{DynamicRegistration: types.CreateBoolPointer(false)},
+					},
+				},
+			},
+			result: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+		},
+	}
 
-func (ts *TestStream) Read(b []byte) (int, error) {
-	for {
-		if ts.closed {
-			return 0, io.EOF
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := startServer()
 
-		r, err := ts.incoming.Read(b)
-		if r > 0 {
-			return r, err
-		} else if err != io.EOF {
-			return r, err
-		}
-		time.Sleep(1 * time.Second)
+			client := bytes.NewBuffer(make([]byte, 0, 1024))
+			server := bytes.NewBuffer(make([]byte, 0, 1024))
+			serverStream := &TestStream{incoming: server, outgoing: client, closed: false}
+			defer serverStream.Close()
+			go s.ServeStream(serverStream)
+
+			clientStream := jsonrpc2.NewBufferedStream(&TestStream{incoming: client, outgoing: server, closed: false}, jsonrpc2.VSCodeObjectCodec{})
+			defer clientStream.Close()
+			conn := jsonrpc2.NewConn(context.Background(), clientStream, &ConfigurationHandler{t: t})
+			initializeCheck(t, conn, tc.params, tc.result())
+		})
 	}
 }
 
-func (ts *TestStream) Write(n []byte) (int, error) {
-	return ts.outgoing.Write(n)
+type registerCapabilityHandler struct {
+	t                  *testing.T
+	responseChannel    chan error
+	registrationParams *protocol.RegistrationParams
 }
 
-func (ts *TestStream) Close() error {
-	ts.closed = true
-	return nil
+func (h *registerCapabilityHandler) Handle(_ context.Context, conn *jsonrpc2.Conn, request *jsonrpc2.Request) {
+	switch request.Method {
+	case protocol.ServerClientRegisterCapability:
+		if !request.Notif && request.Params != nil {
+			h.registrationParams = &protocol.RegistrationParams{}
+			require.NoError(h.t, json.Unmarshal(*request.Params, &h.registrationParams))
+			h.responseChannel <- nil
+		} else {
+			h.responseChannel <- errors.New("malformed client/registerCapability JSON-RPC call")
+		}
+	}
 }
 
-func startServer() *server.Server {
-	docManager := document.NewDocumentManager()
-	s := server.NewServer(docManager)
-	return s
+func TestRegisterCapability(t *testing.T) {
+	testCases := []struct {
+		name               string
+		params             protocol.InitializeParams
+		initializeResult   func() protocol.InitializeResult
+		registrationParams *protocol.RegistrationParams
+	}{
+		{
+			name: "dynamic formatting supported",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Formatting: &protocol.DocumentFormattingClientCapabilities{
+							DynamicRegistration: types.CreateBoolPointer(true),
+						},
+					},
+				},
+			},
+			initializeResult: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+			registrationParams: &protocol.RegistrationParams{
+				Registrations: []protocol.Registration{
+					{
+						ID:     "docker.lsp.dockerbake.textDocument.formatting",
+						Method: "textDocument/formatting",
+						RegisterOptions: map[string]any{
+							"documentSelector": []any{map[string]any{"language": "dockerbake"}},
+						},
+					},
+					{
+						ID:     "docker.lsp.dockercompose.textDocument.formatting",
+						Method: "textDocument/formatting",
+						RegisterOptions: map[string]any{
+							"documentSelector": []any{map[string]any{"language": "dockercompose"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dynamic formatting supported but composeSupport is false",
+			params: protocol.InitializeParams{
+				InitializationOptions: map[string]any{
+					"dockercomposeExperimental": map[string]bool{"composeSupport": false},
+				},
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Formatting: &protocol.DocumentFormattingClientCapabilities{
+							DynamicRegistration: types.CreateBoolPointer(true),
+						},
+					},
+				},
+			},
+			initializeResult: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.RenameProvider = protocol.RenameOptions{PrepareProvider: types.CreateBoolPointer(true)}
+				return expected
+			},
+			registrationParams: &protocol.RegistrationParams{
+				Registrations: []protocol.Registration{
+					{
+						ID:     "docker.lsp.dockerbake.textDocument.formatting",
+						Method: "textDocument/formatting",
+						RegisterOptions: map[string]any{
+							"documentSelector": []any{map[string]any{"language": "dockerbake"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "dynamic rename supported",
+			params: protocol.InitializeParams{
+				Capabilities: protocol.ClientCapabilities{
+					TextDocument: &protocol.TextDocumentClientCapabilities{
+						Rename: &protocol.RenameClientCapabilities{
+							DynamicRegistration: types.CreateBoolPointer(true),
+						},
+					},
+				},
+			},
+			initializeResult: func() protocol.InitializeResult {
+				expected := createGuaranteedInitializeResult()
+				expected.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+				return expected
+			},
+			registrationParams: &protocol.RegistrationParams{
+				Registrations: []protocol.Registration{
+					{
+						ID:     "docker.lsp.dockercompose.textDocument.rename",
+						Method: "textDocument/rename",
+						RegisterOptions: map[string]any{
+							"documentSelector": []any{map[string]any{"language": "dockercompose"}},
+							"prepareProvider":  true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := startServer()
+
+			client := bytes.NewBuffer(make([]byte, 0, 1024))
+			server := bytes.NewBuffer(make([]byte, 0, 1024))
+			serverStream := &TestStream{incoming: server, outgoing: client, closed: false}
+			defer serverStream.Close()
+			go s.ServeStream(serverStream)
+
+			clientStream := jsonrpc2.NewBufferedStream(&TestStream{incoming: client, outgoing: server, closed: false}, jsonrpc2.VSCodeObjectCodec{})
+			defer clientStream.Close()
+			h := registerCapabilityHandler{t: t, responseChannel: make(chan error)}
+			conn := jsonrpc2.NewConn(context.Background(), clientStream, &h)
+			initializeCheck(t, conn, tc.params, tc.initializeResult())
+			require.NoError(t, <-h.responseChannel)
+			require.Equal(t, tc.registrationParams, h.registrationParams)
+		})
+	}
 }

--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -8,10 +8,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/docker/docker-language-server/internal/bake/hcl"
 	"github.com/docker/docker-language-server/internal/configuration"
 	"github.com/docker/docker-language-server/internal/pkg/buildkit"
-	"github.com/docker/docker-language-server/internal/pkg/cli/metadata"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
 	"github.com/docker/docker-language-server/internal/types"
 	"github.com/sourcegraph/jsonrpc2"
@@ -65,56 +63,6 @@ func TestPublishDiagnostics(t *testing.T) {
 	testPublishDiagnostics(t, protocol.InitializeParams{
 		WorkspaceFolders: []protocol.WorkspaceFolder{{Name: "home", URI: homedir}},
 	})
-}
-
-func initialize(t *testing.T, conn *jsonrpc2.Conn, initializeParams protocol.InitializeParams) {
-	if options, ok := initializeParams.InitializationOptions.(map[string]any); ok {
-		options["telemetry"] = "off"
-	} else {
-		initializeParams.InitializationOptions = map[string]string{"telemetry": "off"}
-	}
-	var initializeResult *protocol.InitializeResult
-	err := conn.Call(context.Background(), protocol.MethodInitialize, initializeParams, &initializeResult)
-	require.NoError(t, err)
-
-	syncKind := protocol.TextDocumentSyncKindFull
-	expected := protocol.InitializeResult{
-		Capabilities: protocol.ServerCapabilities{
-			CodeActionProvider:         protocol.CodeActionOptions{},
-			CompletionProvider:         &protocol.CompletionOptions{},
-			DefinitionProvider:         protocol.DefinitionOptions{},
-			DocumentFormattingProvider: protocol.DocumentFormattingOptions{},
-			DocumentHighlightProvider:  &protocol.DocumentHighlightOptions{},
-			DocumentLinkProvider:       &protocol.DocumentLinkOptions{},
-			DocumentSymbolProvider:     protocol.DocumentSymbolOptions{},
-			ExecuteCommandProvider: &protocol.ExecuteCommandOptions{
-				Commands: []string{types.TelemetryCallbackCommandId},
-			},
-			HoverProvider:            protocol.HoverOptions{},
-			InlayHintProvider:        protocol.InlayHintOptions{},
-			InlineCompletionProvider: protocol.InlineCompletionOptions{},
-			RenameProvider: protocol.RenameOptions{
-				PrepareProvider: types.CreateBoolPointer(true),
-			},
-			SemanticTokensProvider: protocol.SemanticTokensOptions{
-				Legend: protocol.SemanticTokensLegend{
-					TokenModifiers: []string{},
-					TokenTypes:     hcl.SemanticTokenTypes,
-				},
-				Full:  true,
-				Range: false,
-			},
-			TextDocumentSync: protocol.TextDocumentSyncOptions{
-				OpenClose: &protocol.True,
-				Change:    &syncKind,
-			},
-		},
-		ServerInfo: &protocol.InitializeResultServerInfo{
-			Name:    "docker-language-server",
-			Version: &metadata.Version,
-		},
-	}
-	requireJsonEqual(t, expected, initializeResult)
 }
 
 func testPublishDiagnostics(t *testing.T, initializeParams protocol.InitializeParams) {

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -142,8 +142,6 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 			dynamicFormatting = true
 			s.registerFormattingCapability()
 		}
-	}
-	if params.Capabilities.TextDocument != nil {
 		if params.Capabilities.TextDocument.Rename != nil &&
 			params.Capabilities.TextDocument.Rename.DynamicRegistration != nil &&
 			*params.Capabilities.TextDocument.Rename.DynamicRegistration {

--- a/internal/pkg/server/initialize.go
+++ b/internal/pkg/server/initialize.go
@@ -133,19 +133,28 @@ func (s *Server) Initialize(ctx *glsp.Context, params *protocol.InitializeParams
 			Version: &metadata.Version,
 		},
 	}
+	dynamicFormatting := false
+	dynamicRename := false
 	if params.Capabilities.TextDocument != nil {
 		if params.Capabilities.TextDocument.Formatting != nil &&
 			params.Capabilities.TextDocument.Formatting.DynamicRegistration != nil &&
 			*params.Capabilities.TextDocument.Formatting.DynamicRegistration {
+			dynamicFormatting = true
 			s.registerFormattingCapability()
 		}
+	}
+	if params.Capabilities.TextDocument != nil {
 		if params.Capabilities.TextDocument.Rename != nil &&
 			params.Capabilities.TextDocument.Rename.DynamicRegistration != nil &&
 			*params.Capabilities.TextDocument.Rename.DynamicRegistration {
+			dynamicRename = true
 			s.registerRenameCapability()
 		}
-	} else {
+	}
+	if !dynamicFormatting {
 		result.Capabilities.DocumentFormattingProvider = protocol.DocumentFormattingOptions{}
+	}
+	if !dynamicRename {
 		result.Capabilities.RenameProvider = protocol.RenameOptions{
 			PrepareProvider: types.CreateBoolPointer(true),
 		}

--- a/internal/pkg/server/server.go
+++ b/internal/pkg/server/server.go
@@ -266,24 +266,25 @@ func (s *Server) updateTelemetrySetting(value string) {
 func (s *Server) registerFormattingCapability() {
 	dockerbakeLanguage := string(protocol.DockerBakeLanguage)
 	dockercomposeLanguage := string(protocol.DockerComposeLanguage)
-	s.registerCapability(
-		[]protocol.Registration{
-			{
-				ID:     "docker.lsp.dockerbake.textDocument.formatting",
-				Method: "textDocument/formatting",
-				RegisterOptions: protocol.TextDocumentRegistrationOptions{
-					DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockerbakeLanguage}},
-				},
-			},
-			{
-				ID:     "docker.lsp.dockercompose.textDocument.formatting",
-				Method: "textDocument/formatting",
-				RegisterOptions: protocol.TextDocumentRegistrationOptions{
-					DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockercomposeLanguage}},
-				},
+	capabilities := []protocol.Registration{
+		{
+			ID:     "docker.lsp.dockerbake.textDocument.formatting",
+			Method: "textDocument/formatting",
+			RegisterOptions: protocol.TextDocumentRegistrationOptions{
+				DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockerbakeLanguage}},
 			},
 		},
-	)
+	}
+	if s.composeSupport {
+		capabilities = append(capabilities, protocol.Registration{
+			ID:     "docker.lsp.dockercompose.textDocument.formatting",
+			Method: "textDocument/formatting",
+			RegisterOptions: protocol.TextDocumentRegistrationOptions{
+				DocumentSelector: &protocol.DocumentSelector{protocol.DocumentFilter{Language: &dockercomposeLanguage}},
+			},
+		})
+	}
+	s.registerCapability(capabilities)
 }
 
 func (s *Server) registerRenameCapability() {


### PR DESCRIPTION
The server will now respond that it supports formatting and/or rename for clients that do not support dynamic registrations for those two features.

Fixes #229.