### PR TITLE
fix: update BakeSchema to support both string and object types for 'o…

### DIFF
--- a/internal/bake/hcl/parser/schema.go
+++ b/internal/bake/hcl/parser/schema.go
@@ -198,7 +198,10 @@ var BakeSchema = &schema.BodySchema{
 					},
 					"output": {
 						IsOptional: true,
-						Constraint: schema.List{Elem: schema.AnyExpression{OfType: cty.String}},
+						Constraint: schema.OneOf{
+							schema.List{Elem: schema.AnyExpression{OfType: cty.String}},
+							schema.List{Elem: schema.Map{Elem: schema.LiteralType{Type: cty.String}}},
+						},
 					},
 					"platforms": {
 						IsOptional: true,


### PR DESCRIPTION
- Modified output attribute constraint to accept both list of strings and list of objects
- Enables support for complex output configurations like type=docker,dest=/path
- Maintains backward compatibility with existing string-only configurations