### PR TITLE
Improve handling of service hovers with surrounding whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Compose
   - textDocument/documentLink
     - consider quotes when calculating the link's range ([#242](https://github.com/docker/docker-language-server/issues/242))
+  - textDocument/hover
+    - prevent YAML hover issues caused by whitespace ([#244](https://github.com/docker/docker-language-server/issues/244))
 
 ## [0.9.0] - 2025-05-26
 

--- a/internal/compose/hover.go
+++ b/internal/compose/hover.go
@@ -42,6 +42,15 @@ func Hover(ctx context.Context, params *protocol.HoverParams, doc document.Compo
 
 func createYamlHover(node *ast.MappingValueNode) *protocol.Hover {
 	split := strings.Split(node.String(), "\n")
+	// remove leading empty lines
+	for i := range len(split) {
+		if strings.TrimSpace(split[i]) == "" {
+			split = split[i+1:]
+			i--
+		} else {
+			break
+		}
+	}
 	skip := -1
 	for i := range len(split) {
 		if skip == -1 {

--- a/internal/compose/hover_test.go
+++ b/internal/compose/hover_test.go
@@ -505,6 +505,28 @@ services:
 				},
 			},
 		},
+		{
+			name: "service hover with whitespace around it",
+			content: `
+services:
+
+  backend:
+    image: hello
+
+  frontend:
+    depends_on:
+      - backend`,
+			line:      8,
+			character: 12,
+			result: &protocol.Hover{
+				Contents: protocol.MarkupContent{
+					Kind: protocol.MarkupKindMarkdown,
+					Value: "```YAML\n" + `backend:
+  image: hello` +
+						"\n```",
+				},
+			},
+		},
 	}
 
 	composeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))


### PR DESCRIPTION
The YAML library includes the whitespace around a node which is not useful to the user for the purposes of generating a hover result. This whitespace will now be stripped from the result which will also help prevent an error in the hover calculation code.

Fixes #244.