### PR TITLE
Insert placeholder markers only if services can be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Compose
+  - textDocument/completion
+    - fix incorrect snippet item that was generated even if there were no choices to suggest ([#283](https://github.com/docker/docker-language-server/issues/283))
+
 ## [0.10.0] - 2025-06-03
 
 ### Added

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -75,7 +75,9 @@ var serviceSuggestionModifier = textEditModifier{
 				services = append(services, completionItemText{newText: service})
 			}
 		}
-		edit.NewText = fmt.Sprintf("%v%v", edit.NewText, createChoiceSnippetText(services))
+		if len(services) > 0 {
+			edit.NewText = fmt.Sprintf("%v%v", edit.NewText, createChoiceSnippetText(services))
+		}
 		return edit
 	},
 }

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -2644,7 +2644,38 @@ services:
 			},
 		},
 		{
-			name: "extends object attributes",
+			name: "extends object attributes with no other services found",
+			content: `
+services:
+  test:
+    image: alpine
+    extends:
+      `,
+			line:      5,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{
+						Label:            "file",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The file path where the service to extend is defined.",
+						TextEdit:         textEdit("file: ", 5, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+					{
+						Label:            "service",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The name of the service to extend.",
+						TextEdit:         textEdit("service: ", 5, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+				},
+			},
+		},
+		{
+			name: "extends object attributes with a service defined",
 			content: `
 services:
   test:


### PR DESCRIPTION
If there are no other services to suggest then the code completion should not use the ${1||} syntax to insert "nothing" into the editor.

Fixes #283.