### PR TITLE
Check extended file before providing service name suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Compose
   - textDocument/completion
     - fix incorrect snippet item that was generated even if there were no choices to suggest ([#283](https://github.com/docker/docker-language-server/issues/283))
+    - stop local service name suggestions if another file has been explicitly specified ([#285](https://github.com/docker/docker-language-server/issues/285))
 
 ## [0.10.0] - 2025-06-03
 

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -2708,6 +2708,89 @@ services:
 			},
 		},
 		{
+			name: "extends object attributes with a file pointing at itself",
+			content: `
+services:
+  test:
+    image: alpine
+    extends:
+      file: compose.yaml
+      
+  test2:
+    image: alpine`,
+			line:      6,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{
+						Label:            "file",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The file path where the service to extend is defined.",
+						TextEdit:         textEdit("file: ", 6, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+					{
+						Label:            "service",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The name of the service to extend.",
+						TextEdit:         textEdit("service: ${1|test2|}", 6, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+				},
+			},
+		},
+		{
+			name: "extends object attributes with a file pointing somewhere else",
+			content: `
+services:
+  test:
+    image: alpine
+    extends:
+      file: non-existent-compose.yaml
+      
+  test2:
+    image: alpine`,
+			line:      6,
+			character: 6,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{
+						Label:            "file",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The file path where the service to extend is defined.",
+						TextEdit:         textEdit("file: ", 6, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+					{
+						Label:            "service",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "The name of the service to extend.",
+						TextEdit:         textEdit("service: ", 6, 6, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+				},
+			},
+		},
+		{
+			name: "extends' service attribute with a file pointing somewhere else",
+			content: `
+services:
+  test:
+    image: alpine
+    extends:
+      file: non-existent-compose.yaml
+      service: 
+  test2:
+    image: alpine`,
+			line:      6,
+			character: 15,
+			list:      nil,
+		},
+		{
 			name: "networks array items",
 			content: `
 services:


### PR DESCRIPTION
If the extended file is not the current file, we should not be suggesting service names from the current file.

Fixes #285.