### PR TITLE
Consider whitespace when using the prefix for code completion suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to the Docker Language Server will be documented in this fil
 - initialize
   - return JSON-RPC error if an invalid URI was sent with the request ([#292](https://github.com/docker/docker-language-server/issues/292))
 - Compose
+  - textDocument/completion
+    - check for whitespace when performing prefix calculations for build target suggestions ([#294](https://github.com/docker/docker-language-server/issues/294))
   - textDocument/hover
     - fix error caused by casting a node without checking its type first ([#290](https://github.com/docker/docker-language-server/issues/290))
 

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -408,7 +408,10 @@ func buildTargetCompletionItems(params *protocol.CompletionParams, manager *docu
 				} else if prefix, ok := path[3].Value.(*ast.StringNode); ok {
 					if int(params.Position.Line) == path[3].Value.GetToken().Position.Line-1 {
 						offset := int(params.Position.Character) - path[3].Value.GetToken().Position.Column + 1
-						return createBuildStageItems(params, manager, dockerfilePath, prefix.Value[0:offset], prefixLength), true
+						// offset can be greater than the length if there's just empty whitespace after the string value
+						if offset <= len(prefix.Value) {
+							return createBuildStageItems(params, manager, dockerfilePath, prefix.Value[0:offset], prefixLength), true
+						}
 					}
 				}
 			}

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -3511,7 +3511,7 @@ services:
 			},
 		},
 		{
-			name:              "invalid prefix with a space is ignored",
+			name:              "invalid prefix with a space inside the string is ignored",
 			dockerfileContent: "FROM busybox as bstage\nFROM alpine as astage",
 			content: `
 services:
@@ -3523,6 +3523,18 @@ services:
 			list: func() *protocol.CompletionList {
 				return &protocol.CompletionList{Items: []protocol.CompletionItem{}}
 			},
+		},
+		{
+			name:              "invalid prefix with a space at the end of the string is ignored",
+			dockerfileContent: "FROM busybox as bstage\nFROM alpine as astage",
+			content: `
+services:
+  postgres:
+    build:
+      target: a `,
+			line:      4,
+			character: 16,
+			list:      func() *protocol.CompletionList { return nil },
 		},
 		{
 			name:              "completion in the middle with a valid prefix",


### PR DESCRIPTION
Fixes #294.