### PR TITLE
Check for document bounds in parameters to prevent internal server error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Compose
   - textDocument/completion
     - check for whitespace when performing prefix calculations for build target suggestions ([#294](https://github.com/docker/docker-language-server/issues/294))
+    - return an empty result instead of an internal server error if the request's parameters are outside the document's bounds ([#296](https://github.com/docker/docker-language-server/issues/296))
   - textDocument/hover
     - fix error caused by casting a node without checking its type first ([#290](https://github.com/docker/docker-language-server/issues/290))
 

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -192,6 +192,9 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 	}
 
 	lines := strings.Split(string(doc.Input()), "\n")
+	if len(lines) <= lspLine {
+		return nil, nil
+	}
 	currentLineTrimmed := strings.TrimSpace(lines[lspLine])
 	if strings.HasPrefix(currentLineTrimmed, "#") {
 		return nil, nil
@@ -206,6 +209,8 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 	} else if len(path) == 1 {
 		return nil, nil
 	} else if path[1].Key.GetToken().Position.Column >= character {
+		return nil, nil
+	} else if len(lines[lspLine]) < character-1 {
 		return nil, nil
 	}
 

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -2487,6 +2487,23 @@ services:
 				},
 			},
 		},
+		{
+			name: "param character is outside document range",
+			content: `
+services:
+  test:
+    `,
+			line:      3,
+			character: 5,
+			list:      nil,
+		},
+		{
+			name:      "param line is outside document range",
+			content:   "",
+			line:      1,
+			character: 0,
+			list:      nil,
+		},
 	}
 
 	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))


### PR DESCRIPTION
Fixes #296.