### PR TITLE
Lock the cache when deleting to prevent concurrent write errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- lock cache manager when deleting to prevent concurrent map writes ([#298](https://github.com/docker/docker-language-server/issues/298))
 - initialize
   - return JSON-RPC error if an invalid URI was sent with the request ([#292](https://github.com/docker/docker-language-server/issues/292))
 - Compose

--- a/internal/cache/manager.go
+++ b/internal/cache/manager.go
@@ -43,10 +43,11 @@ func (c *CacheManagerImpl[T]) Get(key Key) (T, error) {
 	if err == nil {
 		c.cache[cacheKey] = fetched
 		// auto-expire after one hour
-		go func() {
-			time.Sleep(1 * time.Hour)
+		time.AfterFunc(1*time.Hour, func() {
+			c.mutex.Lock()
+			defer c.mutex.Unlock()
 			delete(c.cache, cacheKey)
-		}()
+		})
 	}
 	return fetched, err
 }


### PR DESCRIPTION
Fixes #298.