### PR TITLE
Ensure include node is an array before processing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Compose
   - textDocument/completion
     - fix error case triggered by using code completion before the first node ([#314](https://github.com/docker/docker-language-server/issues/314))
+  - textDocument/hover
+    - protect the processing of included files if the node is not a proper array ([#322](https://github.com/docker/docker-language-server/issues/322))
 - Bake
   - textDocument/inlineCompletion
     - check that the request is within the document's bounds when processing the request ([#318](https://github.com/docker/docker-language-server/issues/318))

--- a/internal/compose/hover_test.go
+++ b/internal/compose/hover_test.go
@@ -1127,6 +1127,18 @@ volumes:
 			character: 13,
 			result:    nil,
 		},
+		{
+			name: "reference missing and include node is invalid",
+			content: `
+include:
+services:
+  backend:
+    volumes:
+      - volA:/mount`,
+			line:      5,
+			character: 10,
+			result:    nil,
+		},
 	}
 
 	composeFile := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))

--- a/internal/pkg/document/dockerComposeDocument.go
+++ b/internal/pkg/document/dockerComposeDocument.go
@@ -130,22 +130,24 @@ func (d *composeDocument) includedPaths() []string {
 		if node, ok := doc.Body.(*ast.MappingNode); ok {
 			for _, topNode := range node.Values {
 				if topNode.Key.GetToken().Value == "include" {
-					for _, sequenceValue := range topNode.Value.(*ast.SequenceNode).Values {
-						if stringArrayItem, ok := sequenceValue.(*ast.StringNode); ok {
-							paths = append(paths, stringArrayItem.Value)
-						} else if includeObject, ok := sequenceValue.(*ast.MappingNode); ok {
-							for _, includeValues := range includeObject.Values {
-								if includeValues.Key.GetToken().Value == "path" {
-									if pathArrayItem, ok := includeValues.Value.(*ast.StringNode); ok {
-										paths = append(paths, pathArrayItem.Value)
-									} else if pathSequence, ok := includeValues.Value.(*ast.SequenceNode); ok {
-										for _, sequenceValue := range pathSequence.Values {
-											if s, ok := sequenceValue.(*ast.StringNode); ok {
-												paths = append(paths, s.Value)
+					if sequenceNode, ok := topNode.Value.(*ast.SequenceNode); ok {
+						for _, sequenceValue := range sequenceNode.Values {
+							if stringArrayItem, ok := sequenceValue.(*ast.StringNode); ok {
+								paths = append(paths, stringArrayItem.Value)
+							} else if includeObject, ok := sequenceValue.(*ast.MappingNode); ok {
+								for _, includeValues := range includeObject.Values {
+									if includeValues.Key.GetToken().Value == "path" {
+										if pathArrayItem, ok := includeValues.Value.(*ast.StringNode); ok {
+											paths = append(paths, pathArrayItem.Value)
+										} else if pathSequence, ok := includeValues.Value.(*ast.SequenceNode); ok {
+											for _, sequenceValue := range pathSequence.Values {
+												if s, ok := sequenceValue.(*ast.StringNode); ok {
+													paths = append(paths, s.Value)
+												}
 											}
 										}
+										break
 									}
-									break
 								}
 							}
 						}

--- a/internal/pkg/document/dockerComposeDocument_test.go
+++ b/internal/pkg/document/dockerComposeDocument_test.go
@@ -112,6 +112,12 @@ include:
   - compose.yaml`,
 			},
 		},
+		{
+			name:            "include node is invalid",
+			content:         "include:",
+			resolved:        true,
+			externalContent: map[string]string{},
+		},
 	}
 
 	folder := os.TempDir()


### PR DESCRIPTION
The include node may not be an array if the user has made a mistake or is not finished editing their Compose file so we should not try to process it if it is not an array.

Fixes #322.