### PR TITLE
Prevent index error if code completion triggered on an empty JSON document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Compose
+  - textDocument/completion
+    - prevent errors if an empty JSON object is the content of the YAML file ([#330](https://github.com/docker/docker-language-server/issues/330))
+
 ## [0.12.0] - 2025-06-12
 
 ### Added

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -187,6 +187,9 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 	if file == nil || len(file.Docs) == 0 {
 		return nil, nil
 	}
+	if m, ok := file.Docs[0].Body.(*ast.MappingNode); ok && len(m.Values) == 0 {
+		return nil, nil
+	}
 
 	lspLine := int(params.Position.Line)
 	topLevelNodeOffset := calculateTopLevelNodeOffset(file)

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -2762,6 +2762,13 @@ services:
 				},
 			},
 		},
+		{
+			name:      "empty JSON object",
+			content:   "{}",
+			line:      0,
+			character: 0,
+			list:      nil,
+		},
 	}
 
 	composeFileURI := fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(filepath.Join(os.TempDir(), "compose.yaml")), "/"))


### PR DESCRIPTION
Fixes #330.