### PR TITLE
Suggest model object attributes for a Compose service

### DIFF
--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -1697,6 +1697,37 @@ services:
 			},
 		},
 		{
+			name: "inner attributes of a model object under the service",
+			content: `
+services:
+  llm:
+    models:
+      other:
+        `,
+			line:      5,
+			character: 8,
+			list: &protocol.CompletionList{
+				Items: []protocol.CompletionItem{
+					{
+						Label:            "endpoint_var",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "Environment variable set to AI model endpoint.",
+						TextEdit:         textEdit("endpoint_var: ", 5, 8, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+					{
+						Label:            "model_var",
+						Detail:           types.CreateStringPointer("string"),
+						Documentation:    "Environment variable set to AI model name.",
+						TextEdit:         textEdit("model_var: ", 5, 8, 0),
+						InsertTextMode:   types.CreateInsertTextModePointer(protocol.InsertTextModeAsIs),
+						InsertTextFormat: types.CreateInsertTextFormatPointer(protocol.InsertTextFormatSnippet),
+					},
+				},
+			},
+		},
+		{
 			name: "inner attributes of the build object under service",
 			content: `
 services:

--- a/internal/compose/schema.go
+++ b/internal/compose/schema.go
@@ -106,6 +106,7 @@ func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffs
 								return recurseNodeProperties(nodes, line, column, nodeOffset+2, nested.Properties, false)
 							}
 						}
+						return recurseNodeProperties(nodes, line, column, nodeOffset+1, property.Properties, false)
 					}
 				}
 			}


### PR DESCRIPTION
The new schema added a new object that is structured differently from other objects we have considered in the past. The code completion code has been updated to handle this case and will now prompt `endpoint_var` and `model_var`.