### PR TITLE
Prevent attribute from being suggested in the wrong offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Compose
+  - textDocument/completion
+    - prevent wildcard object attribute suggestions if the text cursor is not at the right indentation for attributes to be inserted ([#342](https://github.com/docker/docker-language-server/issues/342))
+
 ## [0.13.0] - 2025-07-09
 
 ### Added

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -2632,6 +2632,18 @@ services:
 			list:      nil,
 		},
 		{
+			name: "indentation considered for regexp object properties",
+			content: `
+services:
+  test:
+    networks:
+      abc:
+      `,
+			line:      5,
+			character: 6,
+			list:      nil,
+		},
+		{
 			name: "reservations completion",
 			content: `
 services:
@@ -4319,7 +4331,7 @@ services:
 			},
 		},
 		{
-			name:              "build completion items include autofilled stages when build is empty",
+			name:              "build completion items include autofilled stages when build is empty when build object has other attributes",
 			dockerfileContent: "FROM busybox as bstage\nFROM alpine as astage",
 			content: `
 services:

--- a/internal/compose/schema.go
+++ b/internal/compose/schema.go
@@ -52,6 +52,9 @@ func nodeProperties(nodes []*ast.MappingValueNode, line, column int) ([]*ast.Map
 
 func recurseNodeProperties(nodes []*ast.MappingValueNode, line, column, nodeOffset int, properties map[string]*jsonschema.Schema, arrayAttributes bool) ([]*ast.MappingValueNode, any, bool) {
 	if len(nodes) == nodeOffset {
+		if nodes[len(nodes)-1].Key.GetToken().Position.Column >= column {
+			return nodes, nil, false
+		}
 		return nodes, properties, arrayAttributes
 	}
 	if nodes[nodeOffset].Key.GetToken().Position.Column == column {


### PR DESCRIPTION
As indentation is critical for a YAML file, we should consider it when determining what attributes should be returned instead of blindly returning all attributes regardless of where the text cursor is at.

Fixes #342.