### PR TITLE
Return document links for the extends object's file attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Docker Language Server will be documented in this fil
 - Compose
   - textDocument/documentLink
     - add anchor resolution for all supported document links ([#348](https://github.com/docker/docker-language-server/issues/348))
+    - return document links for the `file` attribute of a service object's `extends` attribute object ([#172](https://github.com/docker/docker-language-server/issues/172))
 
 ### Fixed
 

--- a/internal/compose/documentLink.go
+++ b/internal/compose/documentLink.go
@@ -166,6 +166,11 @@ func scanForLinks(u *url.URL, n *ast.MappingValueNode) []protocol.DocumentLink {
 							if link != nil {
 								links = append(links, *link)
 							}
+
+							link = createdNestedLink(u, serviceAttribute, "extends", "file")
+							if link != nil {
+								links = append(links, *link)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Fixes #172.