### PR TITLE
Add Windows testing to GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,13 @@ jobs:
           go-version: "1.24.3"
 
       - name: Run unit tests
+        env:
+          DOCKER_LANGUAGE_SERVER_WINDOWS_CI: true
         run: go test -timeout 30s github.com/docker/docker-language-server/internal/bake/hcl github.com/docker/docker-language-server/internal/bake/hcl/parser github.com/docker/docker-language-server/internal/compose github.com/docker/docker-language-server/internal/pkg/buildkit github.com/docker/docker-language-server/internal/pkg/document github.com/docker/docker-language-server/internal/scout github.com/docker/docker-language-server/internal/telemetry github.com/docker/docker-language-server/internal/types
 
       - name: Run e2e tests
+        env:
+          DOCKER_LANGUAGE_SERVER_WINDOWS_CI: true
         run: go test -timeout 240s github.com/docker/docker-language-server/e2e-tests
 
   integration-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,21 @@ jobs:
 
       - run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker/lsp:test make test
 
+  windows-test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.3"
+
+      - name: Run unit tests
+        run: go test -timeout 30s github.com/docker/docker-language-server/internal/bake/hcl github.com/docker/docker-language-server/internal/bake/hcl/parser github.com/docker/docker-language-server/internal/compose github.com/docker/docker-language-server/internal/pkg/buildkit github.com/docker/docker-language-server/internal/pkg/document github.com/docker/docker-language-server/internal/scout github.com/docker/docker-language-server/internal/telemetry github.com/docker/docker-language-server/internal/types
+
+      - name: Run e2e tests
+        run: go test -timeout 240s github.com/docker/docker-language-server/e2e-tests
+
   integration-test:
     runs-on: ubuntu-latest
     steps:
@@ -95,6 +110,7 @@ jobs:
     needs:
       - build
       - integration-test
+      - windows-test
     runs-on: ubuntu-latest
 
     strategy:

--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -48,10 +48,14 @@ func (h *PublishDiagnosticsHandler) Handle(_ context.Context, conn *jsonrpc2.Con
 }
 
 func TestPublishDiagnostics(t *testing.T) {
-	if runtime.GOOS == "windows" && os.Getenv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI") == "true" {
-		// not easy to setup Docker and Buildx in Windows CI, skipping for now
-		t.Skip("skipping test on Windows CI")
-		return
+	if runtime.GOOS == "windows" {
+		value, exists := os.LookupEnv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI")
+		t.Logf("Windows testing (DOCKER_LANGUAGE_SERVER_WINDOWS_CI environment variable set=%v, value=%v)", exists, value)
+		if exists && value == "true" {
+			// not easy to setup Docker and Buildx in Windows CI, skipping for now
+			t.Skip("skipping test on Windows CI")
+			return
+		}
 	}
 
 	// ensure the language server works without any workspace folders

--- a/e2e-tests/publishDiagnostics_test.go
+++ b/e2e-tests/publishDiagnostics_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/configuration"
@@ -47,6 +48,12 @@ func (h *PublishDiagnosticsHandler) Handle(_ context.Context, conn *jsonrpc2.Con
 }
 
 func TestPublishDiagnostics(t *testing.T) {
+	if runtime.GOOS == "windows" && os.Getenv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI") == "true" {
+		// not easy to setup Docker and Buildx in Windows CI, skipping for now
+		t.Skip("skipping test on Windows CI")
+		return
+	}
+
 	// ensure the language server works without any workspace folders
 	testPublishDiagnostics(t, protocol.InitializeParams{})
 

--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -127,6 +127,11 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 			for _, child := range nodes {
 				if strings.EqualFold(child.Value, "FROM") {
 					if child.Next != nil && child.Next.Next != nil && strings.EqualFold(child.Next.Next.Value, "AS") && child.Next.Next.Next != nil && child.Next.Next.Next.Value == target {
+						endLineLength := len(lines[child.EndLine-1])
+						// 13 is ASCII for \r
+						if lines[child.EndLine-1][endLineLength-1] == 13 {
+							endLineLength--
+						}
 						return types.CreateDefinitionResult(
 							definitionLinkSupport,
 							protocol.Range{
@@ -136,7 +141,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 								},
 								End: protocol.Position{
 									Line:      uint32(child.EndLine) - 1,
-									Character: uint32(len(lines[child.EndLine-1])),
+									Character: uint32(endLineLength),
 								},
 							},
 							&protocol.Range{
@@ -211,11 +216,16 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 										originSelectionRange.Start.Character = originSelectionRange.Start.Character + 1
 										originSelectionRange.End.Character = originSelectionRange.End.Character - 1
 									}
+									endLineLength := len(lines[node.EndLine-1])
+									// 13 is ASCII for \r
+									if lines[node.EndLine-1][endLineLength-1] == 13 {
+										endLineLength--
+									}
 									return types.CreateDefinitionResult(
 										definitionLinkSupport,
 										protocol.Range{
 											Start: protocol.Position{Line: uint32(node.StartLine) - 1, Character: 0},
-											End:   protocol.Position{Line: uint32(node.EndLine) - 1, Character: uint32(len(lines[node.EndLine-1]))},
+											End:   protocol.Position{Line: uint32(node.EndLine) - 1, Character: uint32(endLineLength)},
 										},
 										&originSelectionRange,
 										protocol.URI(fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(dockerfilePath), "/"))),

--- a/internal/pkg/buildkit/service_test.go
+++ b/internal/pkg/buildkit/service_test.go
@@ -13,10 +13,14 @@ import (
 )
 
 func TestParse(t *testing.T) {
-	if runtime.GOOS == "windows" && os.Getenv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI") == "true" {
-		// not easy to setup Docker and Buildx in Windows CI, skipping for now
-		t.Skip("skipping test on Windows CI")
-		return
+	if runtime.GOOS == "windows" {
+		value, exists := os.LookupEnv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI")
+		t.Logf("Windows testing (DOCKER_LANGUAGE_SERVER_WINDOWS_CI environment variable set=%v, value=%v)", exists, value)
+		if exists && value == "true" {
+			// not easy to setup Docker and Buildx in Windows CI, skipping for now
+			t.Skip("skipping test on Windows CI")
+			return
+		}
 	}
 
 	testCases := []struct {

--- a/internal/pkg/buildkit/service_test.go
+++ b/internal/pkg/buildkit/service_test.go
@@ -2,6 +2,7 @@ package buildkit
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
@@ -12,6 +13,12 @@ import (
 )
 
 func TestParse(t *testing.T) {
+	if runtime.GOOS == "windows" && os.Getenv("DOCKER_LANGUAGE_SERVER_WINDOWS_CI") == "true" {
+		// not easy to setup Docker and Buildx in Windows CI, skipping for now
+		t.Skip("skipping test on Windows CI")
+		return
+	}
+
 	testCases := []struct {
 		name        string
 		content     string


### PR DESCRIPTION
- we will disable the `docker buildx` calls on Windows as it's non-trivial to install Docker on a Windows runner
- added some checks to handle `\r\n` better, will need to refactor this better in the future