### PR TITLE
Refactor path handling code

### DIFF
--- a/internal/bake/hcl/completion.go
+++ b/internal/bake/hcl/completion.go
@@ -68,7 +68,7 @@ func Completion(ctx context.Context, params *protocol.CompletionParams, manager 
 				}
 			}
 
-			dockerfileURI, dockerfilePath, err := bakeDocument.DockerfileDocumentPathForTarget(b)
+			dockerfileURI, dockerfilePath, err := bakeDocument.DockerfileForTarget(b)
 			if dockerfilePath == "" || err != nil {
 				break
 			}

--- a/internal/bake/hcl/definition.go
+++ b/internal/bake/hcl/definition.go
@@ -112,7 +112,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 
 	if literalValueExpr, ok := expression.(*hclsyntax.LiteralValueExpr); ok && sourceBlock != nil && sourceBlock.Type == "target" {
 		if attributeName == "no-cache-filter" || attributeName == "target" {
-			dockerfileURI, dockerfilePath, err := doc.DockerfileDocumentPathForTarget(sourceBlock)
+			dockerfileURI, dockerfilePath, err := doc.DockerfileForTarget(sourceBlock)
 			if dockerfilePath == "" || err != nil {
 				return nil
 			}
@@ -174,7 +174,7 @@ func ResolveExpression(ctx context.Context, definitionLinkSupport bool, manager 
 		for _, item := range objectConsExpression.Items {
 			if isInsideRange(item.KeyExpr.Range(), position) && sourceBlock != nil {
 				if attributeName == "args" && sourceBlock.Type == "target" {
-					dockerfileURI, dockerfilePath, err := doc.DockerfileDocumentPathForTarget(sourceBlock)
+					dockerfileURI, dockerfilePath, err := doc.DockerfileForTarget(sourceBlock)
 					if dockerfilePath == "" || err != nil {
 						return nil
 					}

--- a/internal/bake/hcl/definition_test.go
+++ b/internal/bake/hcl/definition_test.go
@@ -4,45 +4,16 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/docker/docker-language-server/internal/pkg/document"
 	"github.com/docker/docker-language-server/internal/tliron/glsp/protocol"
-	"github.com/docker/docker-language-server/internal/types"
 	"github.com/stretchr/testify/require"
 	"go.lsp.dev/uri"
 )
-
-func TestLocalDockerfileForNonWindows(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.SkipNow()
-		return
-	}
-
-	u, err := url.Parse("file:///home/unix/docker-bake.hcl")
-	require.NoError(t, err)
-	path, err := types.LocalDockerfile(u)
-	require.NoError(t, err)
-	require.Equal(t, "/home/unix/Dockerfile", path)
-}
-
-func TestLocalDockerfileForWindows(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.SkipNow()
-		return
-	}
-
-	u, err := url.Parse("file:///c%3A/Users/windows/docker-bake.hcl")
-	require.NoError(t, err)
-	path, err := types.LocalDockerfile(u)
-	require.NoError(t, err)
-	require.Equal(t, "c:\\Users\\windows\\Dockerfile", path)
-}
 
 func testPaths(t *testing.T) (dockerfilePath, backendDockerfilePath, bakeFilePath string) {
 	wd, err := os.Getwd()

--- a/internal/bake/hcl/diagnosticsCollector_test.go
+++ b/internal/bake/hcl/diagnosticsCollector_test.go
@@ -148,12 +148,12 @@ func TestCollectDiagnostics(t *testing.T) {
 			},
 		},
 		{
-			name:        "args resolution when inherting a parent that points to a var",
+			name:        "args resolution when inheriting a parent that points to a var",
 			content:     "variable var { }\ntarget \"t1\" {\n  inherits = [var]\nargs = {\n    missing = \"value\"\n  }\n}",
 			diagnostics: []protocol.Diagnostic{},
 		},
 		{
-			name:        "args resolution when inherting a parent that points to a ${var}",
+			name:        "args resolution when inheriting a parent that points to a ${var}",
 			content:     "variable var { }\ntarget \"t1\" {\n  inherits = [\"${var}\"]\nargs = {\n    missing = \"value\"\n  }\n}",
 			diagnostics: []protocol.Diagnostic{},
 		},

--- a/internal/bake/hcl/inlayHint.go
+++ b/internal/bake/hcl/inlayHint.go
@@ -25,7 +25,7 @@ func InlayHint(docs *document.Manager, doc document.BakeHCLDocument, rng protoco
 		if block.Type == "target" && len(block.Labels) > 0 {
 			if attribute, ok := block.Body.Attributes["args"]; ok {
 				if expr, ok := attribute.Expr.(*hclsyntax.ObjectConsExpr); ok && len(expr.Items) > 0 {
-					dockerfileURI, dockerfilePath, err := doc.DockerfileDocumentPathForTarget(block)
+					dockerfileURI, dockerfilePath, err := doc.DockerfileForTarget(block)
 					if dockerfilePath != "" && err == nil {
 						_, nodes := document.OpenDockerfile(context.Background(), docs, dockerfileURI, dockerfilePath)
 						args := map[string]string{}

--- a/internal/pkg/document/bakeDocument_test.go
+++ b/internal/pkg/document/bakeDocument_test.go
@@ -116,7 +116,7 @@ target t2 { }`,
 	}
 }
 
-func TestDockerfileDocumentPathForTarget(t *testing.T) {
+func TestDockerfileForTarget(t *testing.T) {
 	root := os.TempDir()
 	tmp := filepath.Join(root, "tmp")
 	tmp2 := filepath.Join(tmp, "tmp2")
@@ -217,7 +217,7 @@ func TestDockerfileDocumentPathForTarget(t *testing.T) {
 			doc := NewBakeHCLDocument(uri.URI(documentURI), 1, []byte(tc.content))
 			body, ok := doc.File().Body.(*hclsyntax.Body)
 			require.True(t, ok)
-			uri, path, err := doc.DockerfileDocumentPathForTarget(body.Blocks[0])
+			uri, path, err := doc.DockerfileForTarget(body.Blocks[0])
 			require.Equal(t, tc.err, err)
 			require.Equal(t, tc.uri, uri)
 			require.Equal(t, tc.path, path)

--- a/internal/pkg/document/manager.go
+++ b/internal/pkg/document/manager.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -45,9 +44,6 @@ func parseDockerfile(dockerfilePath string) ([]byte, *parser.Result, error) {
 }
 
 func OpenDockerfile(ctx context.Context, manager *Manager, documentURI, path string) ([]byte, []*parser.Node) {
-	if documentURI == "" {
-		documentURI = fmt.Sprintf("file:///%v", strings.TrimPrefix(filepath.ToSlash(path), "/"))
-	}
 	doc := manager.Get(ctx, uri.URI(documentURI))
 	if doc != nil {
 		if dockerfile, ok := doc.(DockerfileDocument); ok {

--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -78,18 +78,6 @@ func StripLeadingSlash(folder string) string {
 	return folder
 }
 
-func LocalDockerfile(u *url.URL) (string, error) {
-	return AbsolutePath(u, "Dockerfile")
-}
-
-func AbsolutePath(documentURL *url.URL, path string) (string, error) {
-	documentPath := documentURL.Path
-	if runtime.GOOS == "windows" {
-		documentPath = documentURL.Path[1:]
-	}
-	return filepath.Abs(filepath.Join(filepath.Dir(documentPath), path))
-}
-
 func AbsoluteFolder(documentURL *url.URL) (string, error) {
 	documentPath := documentURL.Path
 	if runtime.GOOS == "windows" {


### PR DESCRIPTION
As part of the refactoring for the URIs with `\\wsl$` as a host, some functions were replaced and are no longer called as we created centralized code paths so that URI handling code can all be in one place. We can now delete some code that is no longer called and has been completely replaced.