### PR TITLE
validate and update vendor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,43 @@ jobs:
           version: v1.64
           args: --timeout 3m --verbose --exclude-dirs lsp
 
+  prepare-validate:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.generate.outputs.targets }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: List targets
+        id: generate
+        uses: docker/bake-action/subaction/list-targets@v6
+        with:
+          target: validate
+
+  validate:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-validate
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.prepare-validate.outputs.targets) }}
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Validate
+        uses: docker/bake-action@v6
+        with:
+          source: .
+          targets: ${{ matrix.target }}
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,17 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+### Run the helper commands
+
+To validate PRs before submitting them you should run:
+
+```
+$ make validate-all
+```
+
+To generate and align vendored files with go modules run:
+
+```
+$ make vendor
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,39 @@
-FROM golang:1.24.3-alpine3.21 AS base
-WORKDIR /build
-RUN apk update && apk upgrade && apk add --no-cache ca-certificates go make && update-ca-certificates
-COPY . .
+# syntax=docker/dockerfile:1
+
+ARG GO_VERSION="1.24"
+ARG ALPINE_VERSION="3.22"
+
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine${ALPINE_VERSION} AS base
+ENV CGO_ENABLED=0
+RUN apk add --no-cache file git rsync make
+WORKDIR /src
+
+FROM base AS build-base
+COPY go.* .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
+FROM build-base AS vendored
+RUN --mount=type=bind,target=.,rw \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod tidy && mkdir /out && cp go.mod go.sum /out
+
+FROM scratch AS vendor-update
+COPY --from=vendored /out /
+
+FROM vendored AS vendor-validate
+RUN --mount=type=bind,target=.,rw <<EOT
+  set -e
+  git add -A
+  cp -rf /out/* .
+  diff=$(git status --porcelain -- go.mod go.sum)
+  if [ -n "$diff" ]; then
+    echo >&2 'ERROR: Vendor result differs. Please vendor your package with "make tidy"'
+    echo "$diff"
+    exit 1
+  fi
+EOT
 
 FROM base AS test
 RUN <<SETUP
@@ -11,5 +43,6 @@ RUN <<SETUP
     mkdir ~/.docker/ ~/.docker/cli-plugins/
     mv buildx-v0.21.2.linux-amd64 ~/.docker/cli-plugins/docker-buildx
 SETUP
+COPY . .
 # use -run=NON_EXISTING to download all the test dependencies
 RUN make install && go test -run=NON_EXISTING ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN --mount=type=bind,target=.,rw <<EOT
   cp -rf /out/* .
   diff=$(git status --porcelain -- go.mod go.sum)
   if [ -n "$diff" ]; then
-    echo >&2 'ERROR: Vendor result differs. Please vendor your package with "make tidy"'
+    echo >&2 'ERROR: Vendor result differs. Please vendor your package with "make vendor"'
     echo "$diff"
     exit 1
   fi

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ vendor:
 .PHONY: validate-vendor
 validate-vendor:
 	docker buildx bake vendor-validate
+
+.PHONY: validate-all
+validate-all: lint validate-vendor

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,36 @@
-.PHONY: test lint tidy install
-
+.PHONY: build
 build:
 	./build.sh
 
+.PHONY: test
 test:
 	gotestsum -- $$(go list ./... | grep -v e2e-tests) -timeout 30s
 	go test $$(go list ./... | grep e2e-tests) -timeout 240s
 
+.PHONY: build-docker-test
 build-docker-test:
 	docker build -t docker/lsp:test --target test .
 
+.PHONY: test-docker
 test-docker: build-docker-test
 	docker run --rm -v /var/run/docker.sock:/var/run/docker.sock docker/lsp:test make test
 
+.PHONY: test-docker-disconnected
 test-docker-disconnected: build-docker-test
 	docker run -e DOCKER_NETWORK_NONE=true --rm -v /var/run/docker.sock:/var/run/docker.sock --network none docker/lsp:test make test
 
+.PHONY: lint
 lint:
 	golangci-lint run --exclude-dirs internal/tliron
 
-tidy:
-	go mod tidy
-
+.PHONY: install
 install:
 	go install ./cmd/docker-language-server
+
+.PHONY: vendor
+vendor:
+	docker buildx bake vendor
+
+.PHONY: validate-vendor
+validate-vendor:
+	docker buildx bake vendor-validate

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,26 @@
+variable "GO_VERSION" {
+  default = null
+}
+
+target "_common" {
+  args = {
+    GO_VERSION = GO_VERSION
+    BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+  }
+}
+
+group "validate" {
+  targets = ["vendor-validate"]
+}
+
+target "vendor-validate" {
+  inherits = ["_common"]
+  target = "vendor-validate"
+  output = ["type=cacheonly"]
+}
+
+target "vendor" {
+  inherits = ["_common"]
+  target = "vendor-update"
+  output = ["."]
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker/docker-language-server
 
-go 1.24.3
+go 1.24.0
 
 require (
 	github.com/bep/debounce v1.2.1


### PR DESCRIPTION
Adds sandboxed vendor update and validation in the Dockerfile. A bake definition has been created to ease the integration as well as a GitHub Actions job.

As follow-up we could look at sandboxing the build process with cross compilation.