### PR TITLE
Prevent file structure code completion if it's not a service

### DIFF
--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -415,12 +415,12 @@ func folderStructureCompletionItems(documentPath document.DocumentPath, path []*
 }
 
 func directoryForPrefix(documentPath document.DocumentPath, path []*ast.MappingValueNode, prefix string) string {
-	if len(path) == 3 && path[2].Key.GetToken().Value == "volumes" {
+	if len(path) == 3 && path[0].Key.GetToken().Value == "services" && path[2].Key.GetToken().Value == "volumes" {
 		if strings.HasPrefix(prefix, "./") {
 			_, folder := types.Concatenate(documentPath.Folder, prefix[0:strings.LastIndex(prefix, "/")], documentPath.WSLDollarSignHost)
 			return folder
 		}
-	} else if len(path) == 4 && path[2].Key.GetToken().Value == "volumes" && path[3].Key.GetToken().Value == "source" {
+	} else if len(path) == 4 && path[0].Key.GetToken().Value == "services" && path[2].Key.GetToken().Value == "volumes" && path[3].Key.GetToken().Value == "source" {
 		if volumes, ok := path[2].Value.(*ast.SequenceNode); ok {
 			for _, node := range volumes.Values {
 				if volume, ok := node.(*ast.MappingNode); ok {

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -4658,6 +4658,29 @@ services:
 			list:      nil,
 		},
 		{
+			name: "suggests nothing when volumes not under a services node",
+			content: `
+services2:
+  test:
+    volumes:
+      - ./`,
+			line:      4,
+			character: 10,
+			list:      nil,
+		},
+		{
+			name: "suggests nothing when volumes object not under a services node",
+			content: `
+services2:
+  test:
+    volumes:
+      - type: bind
+        source: `,
+			line:      5,
+			character: 16,
+			list:      nil,
+		},
+		{
 			name: "suggest file structure with a ./ prefix",
 			content: `
 services:


### PR DESCRIPTION
We should not suggest something given that it says `services2`.
```YAML
services2:
  test:
    volumes:
      - ./
```