### PR TITLE
Support folder structure completions in the dockerfile attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ## [Unreleased]
 
+### Added
+
+- Bake
+  - textDocument/completion
+    - provide local file and folder name suggestions ([#414](https://github.com/docker/docker-language-server/issues/414))
+      - `dockerfile` attribute in a `target` block
+
 ### Fixed
 
 - Bake

--- a/internal/pkg/document/document.go
+++ b/internal/pkg/document/document.go
@@ -38,6 +38,18 @@ func NewDocument(mgr *Manager, u uri.URI, identifier protocol.LanguageIdentifier
 	return NewDockerfileDocument(u, version, input)
 }
 
+func DirectoryForPrefix(documentPath DocumentPath, prefix, defaultValue string, prefixRequired bool) string {
+	idx := strings.LastIndex(prefix, "/")
+	if idx == -1 {
+		if prefixRequired {
+			return defaultValue
+		}
+		return documentPath.Folder
+	}
+	_, folder := types.Concatenate(documentPath.Folder, prefix[0:idx], documentPath.WSLDollarSignHost)
+	return folder
+}
+
 type document struct {
 	uri        uri.URI
 	identifier protocol.LanguageIdentifier

--- a/internal/types/common.go
+++ b/internal/types/common.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -112,4 +113,24 @@ func CreateDefinitionResult(definitionLinkSupport bool, targetRange protocol.Ran
 			TargetURI:            linkURI,
 		},
 	}
+}
+
+func FileStructureCompletionItems(folder string, hideFiles bool) []protocol.CompletionItem {
+	if folder != "" {
+		items := []protocol.CompletionItem{}
+		entries, _ := os.ReadDir(folder)
+		for _, entry := range entries {
+			if entry.IsDir() {
+				item := protocol.CompletionItem{Label: entry.Name()}
+				item.Kind = CreateCompletionItemKindPointer(protocol.CompletionItemKindFolder)
+				items = append(items, item)
+			} else if !hideFiles {
+				item := protocol.CompletionItem{Label: entry.Name()}
+				item.Kind = CreateCompletionItemKindPointer(protocol.CompletionItemKindFile)
+				items = append(items, item)
+			}
+		}
+		return items
+	}
+	return nil
 }


### PR DESCRIPTION
If the `dockerfile` attribute of a `target` block is a regular string with no template extrapolation, we will now support using code completion for navigating the folder structure.

Part of the work for #414.