### PR TITLE
Ignore 4XX errors when hovering over non-standard tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- Dockerfile
+  - textDocument/hover
+    - ignore 4XX errors when hovering over images with a non-standard tag ([#371](https://github.com/docker/docker-language-server/issues/371))
 - Compose
   - textDocument/documentLink
     - stop returning links for alias nodes in included paths ([#439](https://github.com/docker/docker-language-server/issues/439))

--- a/internal/scout/languageGatewayClient.go
+++ b/internal/scout/languageGatewayClient.go
@@ -67,9 +67,11 @@ func (c LanguageGatewayClientImpl) PostImage(ctx context.Context, jwt, image str
 	}
 
 	defer func() { _ = res.Body.Close() }()
-	if res.StatusCode != 200 {
+	if res.StatusCode >= 500 {
 		err := fmt.Errorf("http request failed (%v status code)", res.StatusCode)
 		return ImageResponse{}, err
+	} else if res.StatusCode >= 400 {
+		return ImageResponse{}, nil
 	}
 
 	var imageResponse ImageResponse

--- a/internal/scout/service.go
+++ b/internal/scout/service.go
@@ -59,6 +59,7 @@ func (s *ServiceImpl) Hover(ctx context.Context, documentURI protocol.DocumentUr
 				},
 			}, nil
 		}
+		return nil, nil
 	}
 	return nil, err
 }


### PR DESCRIPTION
Fixes #371.