### PR TITLE
Provide a relative time for the dates in the inlay hints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/bep/debounce v1.2.1
 	github.com/bugsnag/bugsnag-go v2.5.1+incompatible
 	github.com/docker/buildx v0.26.1
+	github.com/dromara/carbon/v2 v2.6.11
 	github.com/go-git/go-git/v5 v5.14.0
 	github.com/goccy/go-yaml v1.18.0
 	github.com/hashicorp/hcl-lang v0.0.0-20250210193002-b2ec3be7c1b8

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQ
 github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dromara/carbon/v2 v2.6.11 h1:wnAWZ+sbza1uXw3r05hExNSCaBPFaarWfUvYAX86png=
+github.com/dromara/carbon/v2 v2.6.11/go.mod h1:7GXqCUplwN1s1b4whGk2zX4+g4CMCoDIZzmjlyt0vLY=
 github.com/elazarl/goproxy v1.7.2 h1:Y2o6urb7Eule09PjlhQRGNsqRfPmYI3KKQLFpCAV3+o=
 github.com/elazarl/goproxy v1.7.2/go.mod h1:82vkLNir0ALaW14Rc399OTTjyNREgmdL2cVoIbS6XaE=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/internal/dockerfile/inlayHint_test.go
+++ b/internal/dockerfile/inlayHint_test.go
@@ -16,6 +16,13 @@ import (
 )
 
 func TestInlayHint(t *testing.T) {
+	// set timezone to UTC for this test so the locale is consistent
+	origTZ := os.Getenv("TZ")
+	require.NoError(t, os.Setenv("TZ", "UTC"))
+	t.Cleanup(func() {
+		require.NoError(t, os.Setenv("TZ", origTZ))
+	})
+
 	testCases := []struct {
 		name       string
 		content    string
@@ -40,9 +47,10 @@ func TestInlayHint(t *testing.T) {
 			},
 			inlayHints: []protocol.InlayHint{
 				{
-					Label:       "(last pushed on 2024-01-27)",
+					Label:       "(last pushed 1 year ago)",
 					PaddingLeft: types.CreateBoolPointer(true),
 					Position:    protocol.Position{Line: 0, Character: 16},
+					Tooltip:     types.CreateAnyPointer("2024-01-27 00:47:58 UTC"),
 				},
 			},
 		},
@@ -74,17 +82,18 @@ func TestInlayHint(t *testing.T) {
 			inlayHints: []protocol.InlayHint{},
 		},
 		{
-			name:    "prom/prometheus:v3.1.0",
-			content: "FROM prom/prometheus:v3.1.0",
+			name:    "prom/prometheus:v2.6.1",
+			content: "FROM prom/prometheus:v2.6.1",
 			rng: protocol.Range{
 				Start: protocol.Position{Line: 0, Character: 0},
 				End:   protocol.Position{Line: 0, Character: 27},
 			},
 			inlayHints: []protocol.InlayHint{
 				{
-					Label:       "(last pushed on 2025-01-02)",
+					Label:       "(last pushed 6 years ago)",
 					PaddingLeft: types.CreateBoolPointer(true),
 					Position:    protocol.Position{Line: 0, Character: 27},
+					Tooltip:     types.CreateAnyPointer("2019-01-15 20:13:35 UTC"),
 				},
 			},
 		},

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,6 +12,10 @@ func CreateDiagnosticSeverityPointer(ds protocol.DiagnosticSeverity) *protocol.D
 	return &ds
 }
 
+func CreateAnyPointer(a any) *any {
+	return &a
+}
+
 func CreateBoolPointer(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
Providing a date forces the user to calculate the difference in their head so it is easier to provide a relative date and then the absolute time as a tooltip.