### PR TITLE
Fetch tags so a released binary does not use a date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
Without an actual tag fetched, the build would incorrectly version the binary with a date instead of the version number.