### PR TITLE
Handle inlay hint requests asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- Dockerfile
+  - textDocument/inlayHint
+    - handle inlay hints asynchronously so that it does not block other LSP messages when trying to fetch image data ([#467](https://github.com/docker/docker-language-server/issues/467))
 - Compose
   - textDocument/documentLink
     - return document links for files referenced in the short-form `volumes` attribute of a service object ([#460](https://github.com/docker/docker-language-server/issues/460))


### PR DESCRIPTION
Inlay hints on Dockerfiles need to fetch data so it can take some time before the result can be returned. This means that everything else gets blocked because all JSON-RPC messages are being handled synchronously at the moment. To alleviate this problem, we will check for inlay hint requests and then handle them in a goroutine asynchronously so that other messages can continue to be processed.

Other messages may be changed to be handled asynchronously in the future but only inlay hint requests will be done this way for the time being. We want to be careful about introducing drastic changes to how messages are being handled as it is critical for the operation of the language server.

Fixes #467.