### PR TITLE
Reduce time spent sleeping in the e2e tests

### DIFF
--- a/e2e-tests/initialize_test.go
+++ b/e2e-tests/initialize_test.go
@@ -46,7 +46,7 @@ func (ts *TestStream) Read(b []byte) (int, error) {
 		} else if err != io.EOF {
 			return r, err
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(1 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Instead of sleeping one second, we should reduce this time to one millisecond so that we are checking more often but also likely moving on to the next message faster. This will significantly reduce the amount of time we spend in our e2e tests.