### PR TITLE
Correct the GitHub Action environment variable reference

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Build for ${{ matrix.os }}-${{ matrix.arch }}
         run: |
-          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} BUGSNAG_API_KEY=${{ secrets.BUGSNAG_API_KEY }} make build
+          GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} BUGSNAG_API_KEY=${{ secrets.BUGSNAG_API_KEY }} TELEMETRY_ENDPOINT=${{ vars.TELEMETRY_ENDPOINT }} TELEMETRY_KEY=${{ secrets.TELEMETRY_KEY }} make build
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
We should be using vars instead of env.

```
Run GOOS=linux GOARCH=amd64 BUGSNAG_API_KEY=*** TELEMETRY_ENDPOINT= TELEMETRY_KEY=*** make build
  GOOS=linux GOARCH=amd64 BUGSNAG_API_KEY=*** TELEMETRY_ENDPOINT= TELEMETRY_KEY=*** make build
```