### PR TITLE
Correct output schema definition for the target block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 All notable changes to the Docker Language Server will be documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- Bake
+  - correct the schema for the `output` attribute of the `target` block so that the list can also contain objects instead of only strings ([#77](https://github.com/docker/docker-language-server/issues/77))
+
 ## [0.20.0] - 2025-10-14
+
+### Added
 
 - Compose
   - update schema to the latest version

--- a/internal/bake/hcl/parser/schema.go
+++ b/internal/bake/hcl/parser/schema.go
@@ -198,7 +198,31 @@ var BakeSchema = &schema.BodySchema{
 					},
 					"output": {
 						IsOptional: true,
-						Constraint: schema.List{Elem: schema.AnyExpression{OfType: cty.String}},
+						Constraint: schema.OneOf{
+							schema.List{Elem: schema.AnyExpression{OfType: cty.String}},
+							schema.List{Elem: schema.Object{
+								Attributes: schema.ObjectAttributes{
+									"type": &schema.AttributeSchema{
+										Constraint: schema.OneOf{
+											schema.LiteralValue{Value: cty.StringVal("local")},
+											schema.LiteralValue{Value: cty.StringVal("tar")},
+											schema.LiteralValue{Value: cty.StringVal("oci")},
+											schema.LiteralValue{Value: cty.StringVal("docker")},
+											schema.LiteralValue{Value: cty.StringVal("image")},
+											schema.LiteralValue{Value: cty.StringVal("registry")},
+										},
+									},
+									"attrs": &schema.AttributeSchema{
+										IsOptional: true,
+										Constraint: schema.Map{Elem: schema.LiteralType{Type: cty.String}},
+									},
+									"dest": &schema.AttributeSchema{
+										IsOptional: true,
+										Constraint: schema.LiteralType{Type: cty.String},
+									},
+								},
+							}},
+						},
 					},
 					"platforms": {
 						IsOptional: true,


### PR DESCRIPTION
The output attribute is a list but it can contain strings or objects.

Fixes #77.