### PR TITLE
Ignore empty prefixes when processing image tag completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the Docker Language Server will be documented in this fil
 
 ### Fixed
 
+- Compose
+  - textDocument/completion
+    - check the prefix string before trying to use it for looking up image tags ([#486](https://github.com/docker/docker-language-server/issues/486))
 - Bake
   - fix parsing error caused by referencing a variable with no value ([#490](https://github.com/docker/docker-language-server/issues/490))
 

--- a/internal/compose/completion.go
+++ b/internal/compose/completion.go
@@ -582,7 +582,7 @@ func buildTargetCompletionItems(params *protocol.CompletionParams, manager *docu
 }
 
 func serviceImageCompletionItems(hub hub.Service, path []*ast.MappingValueNode, prefix string) ([]protocol.CompletionItem, bool) {
-	if len(path) == 3 && path[0].Key.GetToken().Value == "services" && path[2].Key.GetToken().Value == "image" {
+	if len(path) == 3 && path[0].Key.GetToken().Value == "services" && path[2].Key.GetToken().Value == "image" && len(prefix) > 0 {
 		if path[2].Value.GetToken().Type == token.DoubleQuoteType || path[2].Value.GetToken().Type == token.SingleQuoteType {
 			prefix = prefix[1:]
 		}

--- a/internal/compose/completion_test.go
+++ b/internal/compose/completion_test.go
@@ -5509,6 +5509,26 @@ services:
 			character: 15,
 			list:      nil,
 		},
+		{
+			name: "single quoted completion with whitespace preceding the character position",
+			content: `
+services:
+  test:
+    image: ' '`,
+			line:      3,
+			character: 13,
+			list:      nil,
+		},
+		{
+			name: "double quoted completion with whitespace preceding the character position",
+			content: `
+services:
+  test:
+    image: " "`,
+			line:      3,
+			character: 13,
+			list:      nil,
+		},
 	}
 
 	dir := createFileStructure(t)


### PR DESCRIPTION
Fixes #486.